### PR TITLE
Correctly indent output of code actions

### DIFF
--- a/packages/typescript/src/configs/getFormatCodeSettings.ts
+++ b/packages/typescript/src/configs/getFormatCodeSettings.ts
@@ -17,7 +17,7 @@ export async function getFormatCodeSettings(
 	const defaultFormatOptions = ctx.typescript.module.getDefaultFormatCodeSettings();
 
 	return Object.assign({}, defaultFormatOptions, filterUndefined({
-		convertTabsToSpaces: options?.insertSpaces,
+		convertTabsToSpaces: options?.insertSpaces ?? false,
 		tabSize: options?.tabSize,
 		indentSize: options?.tabSize,
 		indentStyle: 2 /** ts.IndentStyle.Smart */,

--- a/packages/typescript/src/configs/getFormatCodeSettings.ts
+++ b/packages/typescript/src/configs/getFormatCodeSettings.ts
@@ -14,28 +14,36 @@ export async function getFormatCodeSettings(
 
 	config = config ?? {};
 
-	return {
-		convertTabsToSpaces: options?.insertSpaces,
-		tabSize: options?.tabSize,
-		indentSize: options?.tabSize,
-		indentStyle: 2 /** ts.IndentStyle.Smart */,
-		newLineCharacter: '\n',
-		insertSpaceAfterCommaDelimiter: config.insertSpaceAfterCommaDelimiter ?? true,
-		insertSpaceAfterConstructor: config.insertSpaceAfterConstructor ?? false,
-		insertSpaceAfterSemicolonInForStatements: config.insertSpaceAfterSemicolonInForStatements ?? true,
-		insertSpaceBeforeAndAfterBinaryOperators: config.insertSpaceBeforeAndAfterBinaryOperators ?? true,
-		insertSpaceAfterKeywordsInControlFlowStatements: config.insertSpaceAfterKeywordsInControlFlowStatements ?? true,
-		insertSpaceAfterFunctionKeywordForAnonymousFunctions: config.insertSpaceAfterFunctionKeywordForAnonymousFunctions ?? true,
-		insertSpaceBeforeFunctionParenthesis: config.insertSpaceBeforeFunctionParenthesis ?? false,
-		insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: config.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis ?? false,
-		insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: config.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets ?? false,
-		insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: config.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces ?? true,
-		insertSpaceAfterOpeningAndBeforeClosingEmptyBraces: config.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces ?? true,
-		insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: config.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces ?? false,
-		insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: config.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces ?? false,
-		insertSpaceAfterTypeAssertion: config.insertSpaceAfterTypeAssertion ?? false,
-		placeOpenBraceOnNewLineForFunctions: config.placeOpenBraceOnNewLineForFunctions ?? false,
-		placeOpenBraceOnNewLineForControlBlocks: config.placeOpenBraceOnNewLineForControlBlocks ?? false,
-		semicolons: config.semicolons ?? 'ignore',
-	};
+	const defaultFormatOptions = ctx.typescript.module.getDefaultFormatCodeSettings()
+
+	return Object.assign({}, defaultFormatOptions, filterUndefined({
+        convertTabsToSpaces: options?.insertSpaces,
+        tabSize: options?.tabSize,
+        indentSize: options?.tabSize,
+        indentStyle: 2 /** ts.IndentStyle.Smart */,
+        newLineCharacter: '\n',
+        insertSpaceAfterCommaDelimiter: config.insertSpaceAfterCommaDelimiter ?? true,
+        insertSpaceAfterConstructor: config.insertSpaceAfterConstructor ?? false,
+        insertSpaceAfterSemicolonInForStatements: config.insertSpaceAfterSemicolonInForStatements ?? true,
+        insertSpaceBeforeAndAfterBinaryOperators: config.insertSpaceBeforeAndAfterBinaryOperators ?? true,
+        insertSpaceAfterKeywordsInControlFlowStatements: config.insertSpaceAfterKeywordsInControlFlowStatements ?? true,
+        insertSpaceAfterFunctionKeywordForAnonymousFunctions: config.insertSpaceAfterFunctionKeywordForAnonymousFunctions ?? true,
+        insertSpaceBeforeFunctionParenthesis: config.insertSpaceBeforeFunctionParenthesis ?? false,
+        insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: config.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis ?? false,
+        insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: config.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets ?? false,
+        insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: config.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces ?? true,
+        insertSpaceAfterOpeningAndBeforeClosingEmptyBraces: config.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces ?? true,
+        insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: config.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces ?? false,
+        insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: config.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces ?? false,
+        insertSpaceAfterTypeAssertion: config.insertSpaceAfterTypeAssertion ?? false,
+        placeOpenBraceOnNewLineForFunctions: config.placeOpenBraceOnNewLineForFunctions ?? false,
+        placeOpenBraceOnNewLineForControlBlocks: config.placeOpenBraceOnNewLineForControlBlocks ?? false,
+        semicolons: config.semicolons ?? 'ignore',
+    }));
+}
+
+function filterUndefined<T extends Record<string, any>>(obj: T) {
+	return Object.fromEntries(
+		Object.entries(obj).filter(([k, v]) => v !== undefined)
+	) as T;
 }

--- a/packages/typescript/src/configs/getFormatCodeSettings.ts
+++ b/packages/typescript/src/configs/getFormatCodeSettings.ts
@@ -14,32 +14,32 @@ export async function getFormatCodeSettings(
 
 	config = config ?? {};
 
-	const defaultFormatOptions = ctx.typescript.module.getDefaultFormatCodeSettings()
+	const defaultFormatOptions = ctx.typescript.module.getDefaultFormatCodeSettings();
 
 	return Object.assign({}, defaultFormatOptions, filterUndefined({
-        convertTabsToSpaces: options?.insertSpaces,
-        tabSize: options?.tabSize,
-        indentSize: options?.tabSize,
-        indentStyle: 2 /** ts.IndentStyle.Smart */,
-        newLineCharacter: '\n',
-        insertSpaceAfterCommaDelimiter: config.insertSpaceAfterCommaDelimiter ?? true,
-        insertSpaceAfterConstructor: config.insertSpaceAfterConstructor ?? false,
-        insertSpaceAfterSemicolonInForStatements: config.insertSpaceAfterSemicolonInForStatements ?? true,
-        insertSpaceBeforeAndAfterBinaryOperators: config.insertSpaceBeforeAndAfterBinaryOperators ?? true,
-        insertSpaceAfterKeywordsInControlFlowStatements: config.insertSpaceAfterKeywordsInControlFlowStatements ?? true,
-        insertSpaceAfterFunctionKeywordForAnonymousFunctions: config.insertSpaceAfterFunctionKeywordForAnonymousFunctions ?? true,
-        insertSpaceBeforeFunctionParenthesis: config.insertSpaceBeforeFunctionParenthesis ?? false,
-        insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: config.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis ?? false,
-        insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: config.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets ?? false,
-        insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: config.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces ?? true,
-        insertSpaceAfterOpeningAndBeforeClosingEmptyBraces: config.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces ?? true,
-        insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: config.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces ?? false,
-        insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: config.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces ?? false,
-        insertSpaceAfterTypeAssertion: config.insertSpaceAfterTypeAssertion ?? false,
-        placeOpenBraceOnNewLineForFunctions: config.placeOpenBraceOnNewLineForFunctions ?? false,
-        placeOpenBraceOnNewLineForControlBlocks: config.placeOpenBraceOnNewLineForControlBlocks ?? false,
-        semicolons: config.semicolons ?? 'ignore',
-    }));
+		convertTabsToSpaces: options?.insertSpaces,
+		tabSize: options?.tabSize,
+		indentSize: options?.tabSize,
+		indentStyle: 2 /** ts.IndentStyle.Smart */,
+		newLineCharacter: '\n',
+		insertSpaceAfterCommaDelimiter: config.insertSpaceAfterCommaDelimiter ?? true,
+		insertSpaceAfterConstructor: config.insertSpaceAfterConstructor ?? false,
+		insertSpaceAfterSemicolonInForStatements: config.insertSpaceAfterSemicolonInForStatements ?? true,
+		insertSpaceBeforeAndAfterBinaryOperators: config.insertSpaceBeforeAndAfterBinaryOperators ?? true,
+		insertSpaceAfterKeywordsInControlFlowStatements: config.insertSpaceAfterKeywordsInControlFlowStatements ?? true,
+		insertSpaceAfterFunctionKeywordForAnonymousFunctions: config.insertSpaceAfterFunctionKeywordForAnonymousFunctions ?? true,
+		insertSpaceBeforeFunctionParenthesis: config.insertSpaceBeforeFunctionParenthesis ?? false,
+		insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: config.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis ?? false,
+		insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: config.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets ?? false,
+		insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: config.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces ?? true,
+		insertSpaceAfterOpeningAndBeforeClosingEmptyBraces: config.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces ?? true,
+		insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: config.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces ?? false,
+		insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: config.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces ?? false,
+		insertSpaceAfterTypeAssertion: config.insertSpaceAfterTypeAssertion ?? false,
+		placeOpenBraceOnNewLineForFunctions: config.placeOpenBraceOnNewLineForFunctions ?? false,
+		placeOpenBraceOnNewLineForControlBlocks: config.placeOpenBraceOnNewLineForControlBlocks ?? false,
+		semicolons: config.semicolons ?? 'ignore',
+	}));
 }
 
 function filterUndefined<T extends Record<string, any>>(obj: T) {

--- a/packages/typescript/src/services/codeActionResolve.ts
+++ b/packages/typescript/src/services/codeActionResolve.ts
@@ -61,13 +61,13 @@ export function resolveRefactorCodeAction(
 		return {
 			...edit,
 			textChanges: edit.textChanges.map((change) => {
-				const changePos = document.positionAt(change.span.start);
+				const { newText, span } = change;
+				const changePos = document.positionAt(span.start);
 				const startLineOffset = document.offsetAt({
 					line: changePos.line,
 					character: 0,
 				});
-				if (/^\s/.test(fullText.slice(startLineOffset))) return change;
-				const { newText, span } = change;
+				if (/^\s/.test(fullText.slice(startLineOffset)) || !newText.split('\n')[0].startsWith('\t')) return change;
 				return {
 					newText: newText.split('\n').map(line => line.replace(/^\t/, '')).join('\n'),
 					span


### PR DESCRIPTION
Fixes https://github.com/vuejs/language-tools/issues/2425

As I understand its not possible to pass format options from the client, so why don't use defaults when options are missing?

But there is another problem: since virtual file is wrapped in function, it always adds leading identation, so I think we need patch output to dedent edits (and patch renameLocation). What do you think?