### PR TITLE
feat(prettier): Move config loading to format call

### DIFF
--- a/packages/prettier/src/index.ts
+++ b/packages/prettier/src/index.ts
@@ -1,5 +1,5 @@
 import type { Service } from '@volar/language-service';
-import { format, resolveConfigFile, resolveConfig, type Options, type ResolveConfigOptions, getFileInfo } from 'prettier';
+import { format, getFileInfo, resolveConfig, resolveConfigFile, type Options, type ResolveConfigOptions } from 'prettier';
 
 export default (
 	options: {
@@ -48,7 +48,6 @@ export default (
 	}
 
 	const languages = options.languages ?? ['html', 'css', 'scss', 'typescript', 'javascript'];
-	const filePrettierOptions = getPrettierConfig(options.resolveConfigOptions);
 
 	return {
 		async provideDocumentFormattingEdits(document, _, formatOptions) {
@@ -56,6 +55,7 @@ export default (
 				return;
 			}
 
+			const filePrettierOptions = getPrettierConfig(options.resolveConfigOptions);
 			const fileInfo = await getFileInfo(context.env.uriToFileName(document.uri), { ignorePath: '.prettierignore' });
 
 			if (fileInfo.ignored) {


### PR DESCRIPTION
Getting the config only once does not work correctly, because it might've been updated in between. Prettier has a cache by default, so this doesn't affect performance.