### PR TITLE
[typescript] provide access to syntatic ls

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -43,6 +43,8 @@ export interface Provide {
 	'typescript/textDocument': (uri: string) => TextDocument | undefined;
 	'typescript/languageService': (document?: TextDocument) => ts.LanguageService;
 	'typescript/languageServiceHost': (document?: TextDocument) => ts.LanguageServiceHost;
+	'typescript/syntacticLanguageService': () => ts.LanguageSeaddrvice;
+	'typescript/syntacticLanguageServiceHost': () => ts.LanguageServiceHost;
 };
 
 export default (): Service<Provide> => (contextOrNull, modules): ReturnType<Service<Provide>> => {
@@ -217,11 +219,17 @@ export default (): Service<Provide> => (contextOrNull, modules): ReturnType<Serv
 				prepareSyntacticService(document);
 				return syntacticCtx.typescript.languageService;
 			},
+			'typescript/syntacticLanguageService': document => {
+				return syntacticCtx.typescript.languageService;
+			},
 			'typescript/languageServiceHost': document => {
 				if (!document || getSemanticServiceSourceFile(document.uri)) {
 					return semanticCtx.typescript.languageServiceHost;
 				}
 				prepareSyntacticService(document);
+				return syntacticCtx.typescript.languageServiceHost;
+			},
+			'typescript/syntacticLanguageServiceHost': document => {
 				return syntacticCtx.typescript.languageServiceHost;
 			},
 		},

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -219,7 +219,7 @@ export default (): Service<Provide> => (contextOrNull, modules): ReturnType<Serv
 				prepareSyntacticService(document);
 				return syntacticCtx.typescript.languageService;
 			},
-			'typescript/syntacticLanguageService': document => {
+			'typescript/syntacticLanguageService': () => {
 				return syntacticCtx.typescript.languageService;
 			},
 			'typescript/languageServiceHost': document => {
@@ -229,7 +229,7 @@ export default (): Service<Provide> => (contextOrNull, modules): ReturnType<Serv
 				prepareSyntacticService(document);
 				return syntacticCtx.typescript.languageServiceHost;
 			},
-			'typescript/syntacticLanguageServiceHost': document => {
+			'typescript/syntacticLanguageServiceHost': () => {
 				return syntacticCtx.typescript.languageServiceHost;
 			},
 		},


### PR DESCRIPTION
ref https://github.com/volarjs/volar.js/pull/33#issuecomment-1631119767
provide an easy way to access syntatic server from volar config so I can decorate syntatic features such as document symbol