### PR TITLE
Use module node16

### DIFF
--- a/packages/eslint/src/index.ts
+++ b/packages/eslint/src/index.ts
@@ -1,7 +1,7 @@
 import type { Service, Diagnostic, CodeAction, ServiceContext } from '@volar/language-service';
 import { ESLint, Linter } from 'eslint';
 import type * as ts from 'typescript/lib/tsserverlibrary';
-import type { Provide } from '../../typescript';
+import type { Provide } from 'volar-service-typescript';
 
 export default (resolveConfig?: (program: ts.Program) => Linter.Config): Service => {
 

--- a/packages/tslint/src/index.ts
+++ b/packages/tslint/src/index.ts
@@ -1,6 +1,6 @@
 import type { Service, Diagnostic, CodeAction, ServiceContext } from '@volar/language-service';
 import type { IRule, RuleFailure } from 'tslint';
-import type { Provide } from '../../typescript';
+import type { Provide } from 'volar-service-typescript';
 
 export default (rules: IRule[]): Service => {
 

--- a/packages/typescript-twoslash-queries/src/index.ts
+++ b/packages/typescript-twoslash-queries/src/index.ts
@@ -1,5 +1,5 @@
 import type { Service, InlayHint, ServiceContext } from '@volar/language-service';
-import type { Provide } from '../../typescript';
+import type { Provide } from 'volar-service-typescript';
 
 export default (): Service => (context: ServiceContext<Provide> | undefined): ReturnType<Service> => ({
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,7 @@
 		"lib": [
 			"ES2021",
 		],
-		"module": "commonjs",
-		"moduleResolution": "node",
+		"module": "node16",
 		"sourceMap": true,
 		"composite": true,
 		"declaration": true,
@@ -14,7 +13,6 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"noUnusedLocals": true,
-		"esModuleInterop": true,
 		"baseUrl": "./",
 		"noEmit": true,
 		"paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 		"lib": [
 			"ES2021",
 		],
-		"module": "node16",
+		"module": "Node16",
 		"sourceMap": true,
 		"composite": true,
 		"declaration": true,


### PR DESCRIPTION
This is the correct setting for modern code bases. It implies `"moduleResolution": "node16"` and `"esModuleInterop": true`.