### PR TITLE
Update package metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/css/LICENSE
+++ b/packages/css/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-css",
 	"version": "0.0.13",
+	"description": "Integrate vscode-css-languageservice into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/css",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"css",
+		"language-service",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/css"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"dependencies": {
 		"vscode-css-languageservice": "^6.2.3",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate vscode-css-languageservice into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/css",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"css",
-		"language-service",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/emmet/LICENSE
+++ b/packages/emmet/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/emmet/package.json
+++ b/packages/emmet/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-emmet",
 	"version": "0.0.13",
+	"description": "Integrate emmet into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/emmet",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"emmet",
+		"language-service",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/emmet"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"dependencies": {
 		"@vscode/emmet-helper": "^2.8.6",

--- a/packages/emmet/package.json
+++ b/packages/emmet/package.json
@@ -1,15 +1,11 @@
 {
 	"name": "volar-service-emmet",
 	"version": "0.0.13",
-	"description": "Integrate emmet into Volar",
+	"description": "Integrate @vscode/emmet-helper into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/emmet",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"emmet",
-		"language-service",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/eslint/LICENSE
+++ b/packages/eslint/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-eslint",
 	"version": "0.0.13",
+	"description": "Integrate ESLint into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/eslint",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"eslint",
+		"language-service",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/eslint"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"devDependencies": {
 		"@types/eslint": "latest",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate ESLint into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/eslint",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"eslint",
-		"language-service",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/html/LICENSE
+++ b/packages/html/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate vscode-languageservice-html into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/html",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"html",
-		"language-service",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-html",
 	"version": "0.0.13",
+	"description": "Integrate vscode-languageservice-html into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/html",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"html",
+		"language-service",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/html"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"dependencies": {
 		"vscode-html-languageservice": "^5.0.4",

--- a/packages/json/LICENSE
+++ b/packages/json/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -1,6 +1,18 @@
 {
 	"name": "volar-service-json",
 	"version": "0.0.13",
+	"description": "Integrate vscode-json-languageservice into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/json",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"json",
+		"jsonc",
+		"language-service",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +23,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/json"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"dependencies": {
 		"vscode-json-languageservice": "^5.2.0",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -3,14 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate vscode-json-languageservice into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/json",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"json",
-		"jsonc",
-		"language-service",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/markdown/LICENSE
+++ b/packages/markdown/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present Remco Haszing
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-markdown",
 	"version": "0.0.13",
+	"description": "Integrate vscode-markdown-languageservice into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/markdown",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"language-service",
+		"markdown",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/markdown"
+	},
+	"author": {
+		"name": "Remco Haszing",
+		"email": "remcohaszing@gmail.com",
+		"url": "https://github.com/remcohaszing"
 	},
 	"dependencies": {
 		"markdown-it": "^13.0.1",

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate vscode-markdown-languageservice into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/markdown",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"language-service",
-		"markdown",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/prettier/LICENSE
+++ b/packages/prettier/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Pacharapol Withayasakpunt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate Prettier into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/prettier",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"language-service",
-		"prettier",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-prettier",
 	"version": "0.0.13",
+	"description": "Integrate Prettier into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/prettier",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"language-service",
+		"prettier",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"types": "out/index.d.ts",
 	"license": "MIT",

--- a/packages/pretty-ts-errors/LICENSE
+++ b/packages/pretty-ts-errors/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pretty-ts-errors/package.json
+++ b/packages/pretty-ts-errors/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-pretty-ts-errors",
 	"version": "0.0.13",
+	"description": "Integrate pretty-ts-errors-lsp into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/pretty-ts-errors",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"language-service",
+		"pretty-ts-errors",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/pretty-ts-errors"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"dependencies": {
 		"pretty-ts-errors-lsp": "^0.0.3"

--- a/packages/pretty-ts-errors/package.json
+++ b/packages/pretty-ts-errors/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate pretty-ts-errors-lsp into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/pretty-ts-errors",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"language-service",
-		"pretty-ts-errors",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/prettyhtml/LICENSE
+++ b/packages/prettyhtml/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/prettyhtml/package.json
+++ b/packages/prettyhtml/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-prettyhtml",
 	"version": "0.0.13",
+	"description": "Integrate prettyhtml into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/prettyhtml",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"language-service",
+		"prettyhtml",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/prettyhtml"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"dependencies": {
 		"@starptech/prettyhtml": "^0.10.0"

--- a/packages/prettyhtml/package.json
+++ b/packages/prettyhtml/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate prettyhtml into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/prettyhtml",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"language-service",
-		"prettyhtml",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/pug-beautify/LICENSE
+++ b/packages/pug-beautify/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pug-beautify/package.json
+++ b/packages/pug-beautify/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-pug-beautify",
 	"version": "0.0.13",
+	"description": "Integrate pug-beautify into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/pug-beautify",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"language-service",
+		"pug-beautify",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/pug-beautify"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"dependencies": {
 		"@johnsoncodehk/pug-beautify": "^0.2.2"

--- a/packages/pug-beautify/package.json
+++ b/packages/pug-beautify/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate pug-beautify into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/pug-beautify",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"language-service",
-		"pug-beautify",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/pug/LICENSE
+++ b/packages/pug/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pug/package.json
+++ b/packages/pug/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate Pug into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/pug",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"language-service",
-		"pug",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/pug/package.json
+++ b/packages/pug/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-pug",
 	"version": "0.0.13",
+	"description": "Integrate Pug into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/pug",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"language-service",
+		"pug",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/pug"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"dependencies": {
 		"@volar/language-service": "~1.10.0",

--- a/packages/sass-formatter/LICENSE
+++ b/packages/sass-formatter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sass-formatter/package.json
+++ b/packages/sass-formatter/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate sass-formatter into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/sass-formatter",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"language-service",
-		"sass-formatter",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/sass-formatter/package.json
+++ b/packages/sass-formatter/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-sass-formatter",
 	"version": "0.0.13",
+	"description": "Integrate sass-formatter into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/sass-formatter",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"language-service",
+		"sass-formatter",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/sass-formatter"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"dependencies": {
 		"sass-formatter": "^0.7.5"

--- a/packages/tsconfig/LICENSE
+++ b/packages/tsconfig/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate tsconfig into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/tsconfig",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"language-service",
-		"tsconfig",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-tsconfig",
 	"version": "0.0.13",
+	"description": "Integrate tsconfig into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/tsconfig",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"language-service",
+		"tsconfig",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/tsconfig"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"devDependencies": {
 		"vscode-languageserver-textdocument": "^1.0.8"

--- a/packages/tslint/LICENSE
+++ b/packages/tslint/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/tslint/package.json
+++ b/packages/tslint/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-tslint",
 	"version": "0.0.13",
+	"description": "Integrate TSLint into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/tslint",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"language-service",
+		"tslint",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/tslint"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"devDependencies": {
 		"tslint": "latest",

--- a/packages/tslint/package.json
+++ b/packages/tslint/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate TSLint into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/tslint",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"language-service",
-		"tslint",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/typescript-twoslash-queries/LICENSE
+++ b/packages/typescript-twoslash-queries/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/typescript-twoslash-queries/package.json
+++ b/packages/typescript-twoslash-queries/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-typescript-twoslash-queries",
 	"version": "0.0.13",
+	"description": "Integrate TypeScript Twoslash into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/typescript-twoslash-queries",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"language-service",
+		"typescript-twoslash-queries",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/typescript-twoslash-queries"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"devDependencies": {
 		"volar-service-typescript": "0.0.13"

--- a/packages/typescript-twoslash-queries/package.json
+++ b/packages/typescript-twoslash-queries/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate TypeScript Twoslash into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/typescript-twoslash-queries",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"language-service",
-		"typescript-twoslash-queries",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/typescript/LICENSE
+++ b/packages/typescript/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate TypeScript into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/typescript",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"language-service",
-		"typescript",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-typescript",
 	"version": "0.0.13",
+	"description": "Integrate TypeScript into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/typescript",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"language-service",
+		"typescript",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/typescript"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"devDependencies": {
 		"@types/semver": "^7.3.13",

--- a/packages/vetur/LICENSE
+++ b/packages/vetur/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Johnson Chu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vetur/package.json
+++ b/packages/vetur/package.json
@@ -3,13 +3,9 @@
 	"version": "0.0.13",
 	"description": "Integrate Vetur into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/vetur",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"language-service",
-		"vetur",
-		"volar",
 		"volar-service"
 	],
 	"main": "out/index.js",

--- a/packages/vetur/package.json
+++ b/packages/vetur/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-vetur",
 	"version": "0.0.13",
+	"description": "Integrate Vetur into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/vetur",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"language-service",
+		"vetur",
+		"volar",
+		"volar-service"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/vetur"
+	},
+	"author": {
+		"name": "Johnson Chu",
+		"email": "johnsoncodehk@gmail.com",
+		"url": "https://github.com/johnsoncodehk"
 	},
 	"dependencies": {
 		"vls": "^0.8.2",

--- a/packages/yaml/LICENSE
+++ b/packages/yaml/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present Remco Haszing
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -3,14 +3,10 @@
 	"version": "0.0.13",
 	"description": "Integrate yaml-language-server into Volar",
 	"homepage": "https://github.com/volarjs/services/tree/master/packages/yaml",
-	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
 	"bugs": "https://github.com/volarjs/services/issues",
 	"sideEffects": false,
 	"keywords": [
-		"language-service",
-		"volar",
-		"volar-service",
-		"yaml"
+		"volar-service"
 	],
 	"main": "out/index.js",
 	"license": "MIT",

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -1,6 +1,17 @@
 {
 	"name": "volar-service-yaml",
 	"version": "0.0.13",
+	"description": "Integrate yaml-language-server into Volar",
+	"homepage": "https://github.com/volarjs/services/tree/master/packages/yaml",
+	"funding": "https://github.com/volarjs/volar.js?sponsor=1",
+	"bugs": "https://github.com/volarjs/services/issues",
+	"sideEffects": false,
+	"keywords": [
+		"language-service",
+		"volar",
+		"volar-service",
+		"yaml"
+	],
 	"main": "out/index.js",
 	"license": "MIT",
 	"files": [
@@ -11,6 +22,11 @@
 		"type": "git",
 		"url": "https://github.com/volarjs/services.git",
 		"directory": "packages/yaml"
+	},
+	"author": {
+		"name": "Remco Haszing",
+		"email": "remcohaszing@gmail.com",
+		"url": "https://github.com/remcohaszing"
 	},
 	"dependencies": {
 		"yaml-language-server": "1.14.0"


### PR DESCRIPTION
This adds the following metadata:

- `description` is rendered on https://npmjs.com
- `homepage` is rendered on https://npmjs.com
- `funding` renders a _Fund_ button on https://npmjs.com and is used by the `npm fund` command
- `bugs` is used by the `npm bugs` command.
- `sideEffects` tells bundlers that importing the package does not have side effects, so it can be tree-shaken safely.
- `keywords` is rendered on https://npmjs.com
- I’m not really sure how `author` is used, but it’s nice to give the author credit, especially in case of external contributors.