### PR TITLE
feat: add markdown trigger characters

### DIFF
--- a/packages/markdown/index.ts
+++ b/packages/markdown/index.ts
@@ -34,6 +34,7 @@ function assert(condition: unknown, message: string): asserts condition {
 export function create(options: CreateOptions): ServicePlugin {
 	return {
 		name: 'markdown',
+		triggerCharacters: ['.', '/', '#'],
 		create(context): ServicePluginInstance<Provide> {
 
 			let lastProjectVersion: string | undefined;


### PR DESCRIPTION
The trigger characters are based on https://github.com/microsoft/vscode/blob/1.85.1/extensions/markdown-language-features/server/src/server.ts#L331.

Refs https://github.com/mdx-js/mdx-analyzer/issues/385