### PR TITLE
feat(css, html, typescript): consume `initialIndentLevel` in embedded code formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
 		"watch": "tsc -b -w",
 		"prerelease": "npm run build",
 		"release": "lerna publish --exact --force-publish --yes --sync-workspace-lock",
-		"postrelease": "lerna exec --no-bail --no-private --no-sort --stream -- '[ -n \"$(npm v . dist-tags.latest)\" ] && npm dist-tag add ${LERNA_PACKAGE_NAME}@$(npm v . dist-tags.latest) volar-2.0'",
+		"postrelease": "lerna exec --no-bail --no-private --no-sort --stream -- '[ -n \"$(npm v . dist-tags.latest)\" ] && npm dist-tag add ${LERNA_PACKAGE_NAME}@$(npm v . dist-tags.latest) volar-2.1'",
 		"release:next": "npm run release -- --dist-tag next"
 	},
 	"devDependencies": {
 		"@lerna-lite/cli": "latest",
 		"@lerna-lite/exec": "latest",
 		"@lerna-lite/publish": "latest",
-		"@volar/language-service": "~2.0.4",
+		"@volar/language-service": "~2.1.0",
 		"typescript": "latest",
 		"vscode-languageserver-protocol": "^3.17.5"
 	}

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -32,7 +32,7 @@
 		"@types/node": "latest"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4"
+		"@volar/language-service": "~2.1.0"
 	},
 	"peerDependenciesMeta": {
 		"@volar/language-service": {

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -25,11 +25,11 @@
 	},
 	"dependencies": {
 		"vscode-css-languageservice": "^6.2.10",
+		"vscode-languageserver-textdocument": "^1.0.11",
 		"vscode-uri": "^3.0.8"
 	},
 	"devDependencies": {
-		"@types/node": "latest",
-		"vscode-languageserver-textdocument": "^1.0.11"
+		"@types/node": "latest"
 	},
 	"peerDependencies": {
 		"@volar/language-service": "~2.0.4"

--- a/packages/emmet/package.json
+++ b/packages/emmet/package.json
@@ -28,7 +28,7 @@
 		"volar-service-html": "0.0.30"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4"
+		"@volar/language-service": "~2.1.0"
 	},
 	"peerDependenciesMeta": {
 		"@volar/language-service": {

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -32,7 +32,7 @@
 		"@types/node": "latest"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4"
+		"@volar/language-service": "~2.1.0"
 	},
 	"peerDependenciesMeta": {
 		"@volar/language-service": {

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -25,11 +25,11 @@
 	},
 	"dependencies": {
 		"vscode-html-languageservice": "^5.1.0",
+		"vscode-languageserver-textdocument": "^1.0.11",
 		"vscode-uri": "^3.0.8"
 	},
 	"devDependencies": {
-		"@types/node": "latest",
-		"vscode-languageserver-textdocument": "^1.0.11"
+		"@types/node": "latest"
 	},
 	"peerDependencies": {
 		"@volar/language-service": "~2.0.4"

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -31,7 +31,7 @@
 		"vscode-languageserver-textdocument": "^1.0.11"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4"
+		"@volar/language-service": "~2.1.0"
 	},
 	"peerDependenciesMeta": {
 		"@volar/language-service": {

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -34,7 +34,7 @@
 		"vscode-languageserver-textdocument": "^1.0.11"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4"
+		"@volar/language-service": "~2.1.0"
 	},
 	"peerDependenciesMeta": {
 		"@volar/language-service": {

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -32,7 +32,7 @@
 		"prettier": "^3.0.3"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4",
+		"@volar/language-service": "~2.1.0",
 		"prettier": "^2.2 || ^3.0"
 	},
 	"peerDependenciesMeta": {

--- a/packages/pretty-ts-errors/package.json
+++ b/packages/pretty-ts-errors/package.json
@@ -27,7 +27,7 @@
 		"pretty-ts-errors-lsp": "^0.0.3"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4"
+		"@volar/language-service": "~2.1.0"
 	},
 	"peerDependenciesMeta": {
 		"@volar/language-service": {

--- a/packages/prettyhtml/package.json
+++ b/packages/prettyhtml/package.json
@@ -27,7 +27,7 @@
 		"@starptech/prettyhtml": "^0.10.0"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4"
+		"@volar/language-service": "~2.1.0"
 	},
 	"peerDependenciesMeta": {
 		"@volar/language-service": {

--- a/packages/pug-beautify/package.json
+++ b/packages/pug-beautify/package.json
@@ -27,7 +27,7 @@
 		"@johnsoncodehk/pug-beautify": "^0.2.2"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4"
+		"@volar/language-service": "~2.1.0"
 	},
 	"peerDependenciesMeta": {
 		"@volar/language-service": {

--- a/packages/pug/index.ts
+++ b/packages/pug/index.ts
@@ -81,7 +81,7 @@ export function create(): ServicePlugin {
 				provideDocumentSymbols(document, token) {
 					return worker(document, async (pugDoc) => {
 
-						const htmlResult = await htmlService.provideDocumentSymbols?.(pugDoc.map.virtualFileDocument, token) ?? [];
+						const htmlResult = await htmlService.provideDocumentSymbols?.(pugDoc.map.embeddedDocument, token) ?? [];
 						const pugResult = htmlResult.map(htmlSymbol => transformDocumentSymbol(
 							htmlSymbol,
 							range => pugDoc.map.getSourceRange(range),

--- a/packages/pug/lib/services/completion.ts
+++ b/packages/pug/lib/services/completion.ts
@@ -53,7 +53,7 @@ export function register(htmlLs: html.LanguageService) {
 		return transformCompletionList(
 			htmlComplete,
 			htmlRange => pugDoc.map.getSourceRange(htmlRange),
-			pugDoc.map.virtualFileDocument,
+			pugDoc.map.embeddedDocument,
 			serviceContext,
 		);
 	};

--- a/packages/pug/lib/services/documentHighlight.ts
+++ b/packages/pug/lib/services/documentHighlight.ts
@@ -10,7 +10,7 @@ export function register(htmlLs: html.LanguageService) {
 			return;
 
 		const htmlResult = htmlLs.findDocumentHighlights(
-			pugDoc.map.virtualFileDocument,
+			pugDoc.map.embeddedDocument,
 			htmlPos,
 			pugDoc.htmlDocument,
 		);

--- a/packages/pug/lib/services/documentLinks.ts
+++ b/packages/pug/lib/services/documentLinks.ts
@@ -6,7 +6,7 @@ export function register(htmlLs: html.LanguageService) {
 	return (pugDoc: PugDocument, docContext: html.DocumentContext) => {
 
 		const htmlResult = htmlLs.findDocumentLinks(
-			pugDoc.map.virtualFileDocument,
+			pugDoc.map.embeddedDocument,
 			docContext,
 		);
 

--- a/packages/pug/lib/services/hover.ts
+++ b/packages/pug/lib/services/hover.ts
@@ -10,7 +10,7 @@ export function register(htmlLs: html.LanguageService) {
 			return;
 
 		const htmlResult = htmlLs.doHover(
-			pugDoc.map.virtualFileDocument,
+			pugDoc.map.embeddedDocument,
 			htmlPos,
 			pugDoc.htmlDocument,
 			options,

--- a/packages/pug/lib/services/selectionRanges.ts
+++ b/packages/pug/lib/services/selectionRanges.ts
@@ -10,7 +10,7 @@ export function register(htmlLs: html.LanguageService) {
 			.filter((v): v is NonNullable<typeof v> => !!v);
 
 		const htmlResult = htmlLs.getSelectionRanges(
-			pugDoc.map.virtualFileDocument,
+			pugDoc.map.embeddedDocument,
 			htmlPosArr,
 		);
 

--- a/packages/pug/package.json
+++ b/packages/pug/package.json
@@ -24,7 +24,7 @@
 		"url": "https://github.com/johnsoncodehk"
 	},
 	"dependencies": {
-		"@volar/language-service": "~2.0.4",
+		"@volar/language-service": "~2.1.0",
 		"pug-lexer": "^5.0.1",
 		"pug-parser": "^6.0.0",
 		"volar-service-html": "0.0.30",

--- a/packages/sass-formatter/package.json
+++ b/packages/sass-formatter/package.json
@@ -27,7 +27,7 @@
 		"sass-formatter": "^0.7.8"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4"
+		"@volar/language-service": "~2.1.0"
 	},
 	"peerDependenciesMeta": {
 		"@volar/language-service": {

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -32,7 +32,7 @@
 		"vscode-uri": "^3.0.8"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4"
+		"@volar/language-service": "~2.1.0"
 	},
 	"peerDependenciesMeta": {
 		"@volar/language-service": {

--- a/packages/typescript-twoslash-queries/package.json
+++ b/packages/typescript-twoslash-queries/package.json
@@ -27,7 +27,7 @@
 		"volar-service-typescript": "0.0.30"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4"
+		"@volar/language-service": "~2.1.0"
 	},
 	"peerDependenciesMeta": {
 		"@volar/language-service": {

--- a/packages/typescript/lib/configs/getFormatCodeSettings.ts
+++ b/packages/typescript/lib/configs/getFormatCodeSettings.ts
@@ -9,16 +9,12 @@ export async function getFormatCodeSettings(
 	document: TextDocument,
 	options?: FormattingOptions,
 ): Promise<ts.FormatCodeSettings> {
-
-	let config = await ctx.env.getConfiguration?.<any>(getConfigTitle(document) + '.format');
-
-	config = config ?? {};
-
+	const config = await ctx.env.getConfiguration?.<any>(getConfigTitle(document) + '.format') ?? {};
 	return {
 		convertTabsToSpaces: options?.insertSpaces,
 		tabSize: options?.tabSize,
 		indentSize: options?.tabSize,
-		indentStyle: 2 /** ts.IndentStyle.Smart */,
+		indentStyle: 2 satisfies ts.IndentStyle.Smart,
 		newLineCharacter: '\n',
 		insertSpaceAfterCommaDelimiter: config.insertSpaceAfterCommaDelimiter ?? true,
 		insertSpaceAfterConstructor: config.insertSpaceAfterConstructor ?? false,

--- a/packages/typescript/lib/features/formatting.ts
+++ b/packages/typescript/lib/features/formatting.ts
@@ -6,16 +6,22 @@ import type { SharedContext } from '../types';
 
 export function register(ctx: SharedContext) {
 	return {
-		onRange: async (document: TextDocument, range: vscode.Range | undefined, options: vscode.FormattingOptions): Promise<vscode.TextEdit[]> => {
+		onRange: async (document: TextDocument, range: vscode.Range | undefined, options: vscode.FormattingOptions, codeOptions: vscode.EmbeddedCodeFormattingOptions | undefined): Promise<vscode.TextEdit[]> => {
 
 			const fileName = ctx.uriToFileName(document.uri);
 			const tsOptions = await getFormatCodeSettings(ctx, document, options);
-			if (typeof (tsOptions.indentSize) === "boolean" || typeof (tsOptions.indentSize) === "string") {
-				tsOptions.indentSize = undefined;
+
+			if (codeOptions) {
+				tsOptions.baseIndentSize = codeOptions.initialIndentLevel * options.tabSize;
 			}
 
 			const scriptEdits = range
-				? safeCall(() => ctx.languageService.getFormattingEditsForRange(fileName, document.offsetAt(range.start), document.offsetAt(range.end), tsOptions))
+				? safeCall(() => ctx.languageService.getFormattingEditsForRange(
+					fileName,
+					document.offsetAt(range.start),
+					document.offsetAt(range.end),
+					tsOptions,
+				))
 				: safeCall(() => ctx.languageService.getFormattingEditsForDocument(fileName, tsOptions));
 			if (!scriptEdits) return [];
 
@@ -33,10 +39,15 @@ export function register(ctx: SharedContext) {
 
 			return result;
 		},
-		onType: async (document: TextDocument, options: vscode.FormattingOptions, position: vscode.Position, key: string): Promise<vscode.TextEdit[]> => {
+		onType: async (document: TextDocument, options: vscode.FormattingOptions, codeOptions: vscode.EmbeddedCodeFormattingOptions | undefined, position: vscode.Position, key: string): Promise<vscode.TextEdit[]> => {
 
 			const fileName = ctx.uriToFileName(document.uri);
 			const tsOptions = await getFormatCodeSettings(ctx, document, options);
+
+			if (codeOptions) {
+				tsOptions.baseIndentSize = codeOptions.initialIndentLevel * options.tabSize;
+			}
+
 			const scriptEdits = safeCall(() => ctx.languageService.getFormattingEditsAfterKeystroke(fileName, document.offsetAt(position), key, tsOptions));
 			if (!scriptEdits) return [];
 

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -36,8 +36,8 @@
 		"vscode-nls": "^5.2.0"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4",
-		"@volar/typescript": "~2.0.4"
+		"@volar/language-service": "~2.1.0",
+		"@volar/typescript": "~2.1.0"
 	},
 	"peerDependenciesMeta": {
 		"@volar/language-service": {

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -33,8 +33,7 @@
 		"semver": "^7.5.4",
 		"typescript-auto-import-cache": "^0.3.1",
 		"vscode-languageserver-textdocument": "^1.0.11",
-		"vscode-nls": "^5.2.0",
-		"vscode-uri": "^3.0.8"
+		"vscode-nls": "^5.2.0"
 	},
 	"peerDependencies": {
 		"@volar/language-service": "~2.0.4",

--- a/packages/vetur/package.json
+++ b/packages/vetur/package.json
@@ -28,7 +28,7 @@
 		"vscode-html-languageservice": "^5.1.0"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4"
+		"@volar/language-service": "~2.1.0"
 	},
 	"peerDependenciesMeta": {
 		"@volar/language-service": {

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -30,7 +30,7 @@
 		"vscode-languageserver-textdocument": "^1.0.11"
 	},
 	"peerDependencies": {
-		"@volar/language-service": "~2.0.4"
+		"@volar/language-service": "~2.1.0"
 	},
 	"peerDependenciesMeta": {
 		"@volar/language-service": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       vscode-css-languageservice:
         specifier: ^6.2.10
         version: 6.2.12
+      vscode-languageserver-textdocument:
+        specifier: ^1.0.11
+        version: 1.0.11
       vscode-uri:
         specifier: ^3.0.8
         version: 3.0.8
@@ -42,9 +45,6 @@ importers:
       '@types/node':
         specifier: latest
         version: 20.11.17
-      vscode-languageserver-textdocument:
-        specifier: ^1.0.11
-        version: 1.0.11
 
   packages/emmet:
     dependencies:
@@ -66,6 +66,9 @@ importers:
       vscode-html-languageservice:
         specifier: ^5.1.0
         version: 5.1.2
+      vscode-languageserver-textdocument:
+        specifier: ^1.0.11
+        version: 1.0.11
       vscode-uri:
         specifier: ^3.0.8
         version: 3.0.8
@@ -73,9 +76,6 @@ importers:
       '@types/node':
         specifier: latest
         version: 20.11.17
-      vscode-languageserver-textdocument:
-        specifier: ^1.0.11
-        version: 1.0.11
 
   packages/json:
     dependencies:
@@ -238,9 +238,6 @@ importers:
       vscode-nls:
         specifier: ^5.2.0
         version: 5.2.0
-      vscode-uri:
-        specifier: ^3.0.8
-        version: 3.0.8
     devDependencies:
       '@types/path-browserify':
         specifier: latest


### PR DESCRIPTION
Implement https://github.com/volarjs/volar.js/pull/138, fix https://github.com/microsoft/vscode/pull/171547 formatting tests.