### PR TITLE
refactor: make all editor settings configurable

### DIFF
--- a/packages/css/index.ts
+++ b/packages/css/index.ts
@@ -1,70 +1,111 @@
-import type { CodeAction, Diagnostic, LocationLink, ServicePluginInstance, ServicePlugin } from '@volar/language-service';
+import type { CodeAction, Diagnostic, LocationLink, ServicePluginInstance, ServicePlugin, ServiceContext, DocumentSelector, Disposable } from '@volar/language-service';
 import * as css from 'vscode-css-languageservice';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI, Utils } from 'vscode-uri';
 
 export interface Provide {
 	'css/stylesheet': (document: TextDocument) => css.Stylesheet | undefined;
-	'css/languageService': (languageId: string) => css.LanguageService | undefined;
+	'css/languageService': (document: TextDocument) => css.LanguageService | undefined;
 }
 
-export function create(): ServicePlugin {
+export function create({
+	cssDocumentSelector = ['css'],
+	scssDocumentSelector = ['scss'],
+	lessDocumentSelector = ['less'],
+	useDefaultDataProvider = true,
+	getDocumentContext = context => {
+		return {
+			resolveReference(ref, base) {
+				if (ref.match(/^\w[\w\d+.-]*:/)) {
+					// starts with a schema
+					return ref;
+				}
+				if (ref[0] === '/') { // resolve absolute path against the current workspace folder
+					let folderUri = context.env.workspaceFolder;
+					if (!folderUri.endsWith('/')) {
+						folderUri += '/';
+					}
+					return folderUri + ref.substring(1);
+				}
+				const baseUri = URI.parse(base);
+				const baseUriDir = baseUri.path.endsWith('/') ? baseUri : Utils.dirname(baseUri);
+				return Utils.resolvePath(baseUriDir, ref).toString(true);
+			},
+		};
+	},
+	isFormattingEnabled = async (document, context) => {
+		return await context.env.getConfiguration?.(document.languageId + '.format.enable') ?? true;
+	},
+	getFormatConfiguration = async (document, context) => {
+		return await context.env.getConfiguration?.(document.languageId + '.format');
+	},
+	getLanguageSettings = async (document, context) => {
+		return await context.env.getConfiguration?.(document.languageId);
+	},
+	getCustomData = async context => {
+		const customData: string[] = await context.env.getConfiguration?.('css.customData') ?? [];
+		const newData: css.ICSSDataProvider[] = [];
+		for (const customDataPath of customData) {
+			const uri = Utils.resolvePath(URI.parse(context.env.workspaceFolder), customDataPath);
+			const json = await context.env.fs?.readFile?.(uri.toString());
+			if (json) {
+				try {
+					const data = JSON.parse(json);
+					newData.push(css.newCSSDataProvider(data));
+				}
+				catch (error) {
+					console.error(error);
+				}
+			}
+		}
+		return newData;
+	},
+	onDidChangeCustomData = (listener, context) => {
+		const disposable = context.env.onDidChangeConfiguration?.(listener);
+		return {
+			dispose() {
+				disposable?.dispose();
+			},
+		};
+	},
+}: {
+	cssDocumentSelector?: DocumentSelector,
+	scssDocumentSelector?: DocumentSelector,
+	lessDocumentSelector?: DocumentSelector,
+	useDefaultDataProvider?: boolean;
+	getDocumentContext?(context: ServiceContext): css.DocumentContext;
+	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
+	getFormatConfiguration?(document: TextDocument, context: ServiceContext): Promise<css.CSSFormatConfiguration | undefined>;
+	getLanguageSettings?(document: TextDocument, context: ServiceContext): Promise<css.LanguageSettings | undefined>;
+	getCustomData?(context: ServiceContext): Promise<css.ICSSDataProvider[]>;
+	onDidChangeCustomData?(listener: () => void, context: ServiceContext): Disposable;
+} = {}): ServicePlugin {
 	return {
 		name: 'css',
 		// https://github.com/microsoft/vscode/blob/09850876e652688fb142e2e19fd00fd38c0bc4ba/extensions/css-language-features/server/src/cssServer.ts#L97
 		triggerCharacters: ['/', '-', ':'],
 		create(context): ServicePluginInstance<Provide> {
 
-			let inited = false;
-
 			const stylesheets = new WeakMap<TextDocument, [number, css.Stylesheet]>();
 			const fileSystemProvider: css.FileSystemProvider = {
-				stat: async uri => await context.env.fs?.stat(uri) ?? {
-					type: css.FileType.Unknown,
-					ctime: 0,
-					mtime: 0,
-					size: 0,
-				},
-				readDirectory: async (uri) => await context.env.fs?.readDirectory(uri) ?? [],
+				stat: async uri => await context.env.fs?.stat(uri)
+					?? { type: css.FileType.Unknown, ctime: 0, mtime: 0, size: 0 },
+				readDirectory: async uri => await context.env.fs?.readDirectory(uri) ?? [],
 			};
-			const documentContext: css.DocumentContext = {
-				resolveReference(ref, base) {
-					if (ref.match(/^\w[\w\d+.-]*:/)) {
-						// starts with a schema
-						return ref;
-					}
-					if (ref[0] === '/') { // resolve absolute path against the current workspace folder
-						return base + ref;
-					}
-					const baseUri = URI.parse(base);
-					const baseUriDir = baseUri.path.endsWith('/') ? baseUri : Utils.dirname(baseUri);
-					return Utils.resolvePath(baseUriDir, ref).toString(true);
-				},
-			};
-			const cssLs = css.getCSSLanguageService({
-				fileSystemProvider,
-				clientCapabilities: context.env.clientCapabilities,
-			});
-			const scssLs = css.getSCSSLanguageService({
-				fileSystemProvider,
-				clientCapabilities: context.env.clientCapabilities,
-			});
-			const lessLs = css.getLESSLanguageService({
-				fileSystemProvider,
-				clientCapabilities: context.env.clientCapabilities,
-			});
-			const postcssLs: css.LanguageService = {
-				...scssLs,
-				doValidation: (document, stylesheet, documentSettings) => {
-					let errors = scssLs.doValidation(document, stylesheet, documentSettings);
-					errors = errors.filter(error => error.code !== 'css-semicolonexpected');
-					errors = errors.filter(error => error.code !== 'css-ruleorselectorexpected');
-					errors = errors.filter(error => error.code !== 'unknownAtRules');
-					return errors;
-				},
-			};
+			const documentContext = getDocumentContext(context);
+			const disposable = onDidChangeCustomData(() => initializing = undefined, context);
+
+			let cssLs: css.LanguageService | undefined;
+			let scssLs: css.LanguageService | undefined;
+			let lessLs: css.LanguageService | undefined;
+			let customData: css.ICSSDataProvider[] = [];
+			let initializing: Promise<void> | undefined;
 
 			return {
+
+				dispose() {
+					disposable.dispose();
+				},
 
 				provide: {
 					'css/stylesheet': getStylesheet,
@@ -73,11 +114,8 @@ export function create(): ServicePlugin {
 
 				async provideCompletionItems(document, position) {
 					return worker(document, async (stylesheet, cssLs) => {
-
-						const settings = await context.env.getConfiguration?.<css.LanguageSettings>(document.languageId);
-						const cssResult = await cssLs.doComplete2(document, position, stylesheet, documentContext, settings?.completion);
-
-						return cssResult;
+						const settings = await getLanguageSettings(document, context);
+						return await cssLs.doComplete2(document, position, stylesheet, documentContext, settings?.completion);
 					});
 				},
 
@@ -101,9 +139,7 @@ export function create(): ServicePlugin {
 
 				provideDefinition(document, position) {
 					return worker(document, (stylesheet, cssLs) => {
-
 						const location = cssLs.findDefinition(document, position, stylesheet);
-
 						if (location) {
 							return [{
 								targetUri: location.uri,
@@ -116,18 +152,14 @@ export function create(): ServicePlugin {
 
 				async provideDiagnostics(document) {
 					return worker(document, async (stylesheet, cssLs) => {
-
-						const settings = await context.env.getConfiguration?.<css.LanguageSettings>(document.languageId);
-
+						const settings = await getLanguageSettings(document, context);
 						return cssLs.doValidation(document, stylesheet, settings) as Diagnostic[];
 					});
 				},
 
 				async provideHover(document, position) {
 					return worker(document, async (stylesheet, cssLs) => {
-
-						const settings = await context.env.getConfiguration?.<css.LanguageSettings>(document.languageId);
-
+						const settings = await getLanguageSettings(document, context);
 						return cssLs.doHover(document, position, stylesheet, settings?.hover);
 					});
 				},
@@ -183,11 +215,11 @@ export function create(): ServicePlugin {
 				async provideDocumentFormattingEdits(document, formatRange, options, codeOptions) {
 					return worker(document, async (_stylesheet, cssLs) => {
 
-						const formatSettings = await context.env.getConfiguration?.<css.CSSFormatConfiguration & { enable: boolean; }>(document.languageId + '.format');
-						if (formatSettings?.enable === false) {
+						if (!await isFormattingEnabled(document, context)) {
 							return;
 						}
 
+						const formatSettings = await getFormatConfiguration(document, context);
 						const formatOptions: css.CSSFormatConfiguration = {
 							...options,
 							...formatSettings,
@@ -281,50 +313,30 @@ export function create(): ServicePlugin {
 				},
 			};
 
-			async function initCustomData() {
-				if (!inited) {
-
-					context.env.onDidChangeConfiguration?.(async () => {
-						const customData = await getCustomData();
-						cssLs.setDataProviders(true, customData);
-						scssLs.setDataProviders(true, customData);
-						lessLs.setDataProviders(true, customData);
+			function getCssLs(document: TextDocument): css.LanguageService | undefined {
+				if (matchDocument(cssDocumentSelector, document)) {
+					return cssLs ??= css.getCSSLanguageService({
+						fileSystemProvider,
+						clientCapabilities: context.env.clientCapabilities,
+						useDefaultDataProvider,
+						customDataProviders: customData,
 					});
-
-					const customData = await getCustomData();
-					cssLs.setDataProviders(true, customData);
-					scssLs.setDataProviders(true, customData);
-					lessLs.setDataProviders(true, customData);
-					inited = true;
 				}
-			}
-
-			async function getCustomData() {
-
-				const customData: string[] = await context.env.getConfiguration?.('css.customData') ?? [];
-				const newData: css.ICSSDataProvider[] = [];
-
-				for (const customDataPath of customData) {
-					try {
-						const pathModuleName = 'path'; // avoid bundle
-						const { posix: path } = require(pathModuleName) as typeof import('path');
-						const jsonPath = path.resolve(customDataPath);
-						newData.push(css.newCSSDataProvider(require(jsonPath)));
-					}
-					catch (error) {
-						console.error(error);
-					}
+				else if (matchDocument(scssDocumentSelector, document)) {
+					return scssLs ??= css.getSCSSLanguageService({
+						fileSystemProvider,
+						clientCapabilities: context.env.clientCapabilities,
+						useDefaultDataProvider,
+						customDataProviders: customData,
+					});
 				}
-
-				return newData;
-			}
-
-			function getCssLs(lang: string) {
-				switch (lang) {
-					case 'css': return cssLs;
-					case 'scss': return scssLs;
-					case 'less': return lessLs;
-					case 'postcss': return postcssLs;
+				else if (matchDocument(lessDocumentSelector, document)) {
+					return lessLs ??= css.getLESSLanguageService({
+						fileSystemProvider,
+						clientCapabilities: context.env.clientCapabilities,
+						useDefaultDataProvider,
+						customDataProviders: customData,
+					});
 				}
 			}
 
@@ -338,7 +350,7 @@ export function create(): ServicePlugin {
 					}
 				}
 
-				const cssLs = getCssLs(document.languageId);
+				const cssLs = getCssLs(document);
 				if (!cssLs)
 					return;
 
@@ -354,14 +366,30 @@ export function create(): ServicePlugin {
 				if (!stylesheet)
 					return;
 
-				const cssLs = getCssLs(document.languageId);
+				const cssLs = getCssLs(document);
 				if (!cssLs)
 					return;
 
-				await initCustomData();
+				await (initializing ??= initialize());
 
 				return callback(stylesheet, cssLs);
 			}
+
+			async function initialize() {
+				customData = await getCustomData(context);
+				cssLs?.setDataProviders(useDefaultDataProvider, customData);
+				scssLs?.setDataProviders(useDefaultDataProvider, customData);
+				lessLs?.setDataProviders(useDefaultDataProvider, customData);
+			}
 		},
 	};
+}
+
+function matchDocument(selector: DocumentSelector, document: TextDocument) {
+	for (const sel of selector) {
+		if (sel === document.languageId || (typeof sel === 'object' && sel.language === document.languageId)) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/packages/css/index.ts
+++ b/packages/css/index.ts
@@ -1,4 +1,4 @@
-import type { CodeAction, Diagnostic, LocationLink, ServicePluginInstance, ServicePlugin, ServiceContext, DocumentSelector, Disposable } from '@volar/language-service';
+import type { CodeAction, Diagnostic, Disposable, DocumentSelector, LocationLink, Result, ServiceContext, ServicePlugin, ServicePluginInstance } from '@volar/language-service';
 import * as css from 'vscode-css-languageservice';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI, Utils } from 'vscode-uri';
@@ -74,10 +74,10 @@ export function create({
 	lessDocumentSelector?: DocumentSelector,
 	useDefaultDataProvider?: boolean;
 	getDocumentContext?(context: ServiceContext): css.DocumentContext;
-	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
-	getFormatConfiguration?(document: TextDocument, context: ServiceContext): Promise<css.CSSFormatConfiguration | undefined>;
-	getLanguageSettings?(document: TextDocument, context: ServiceContext): Promise<css.LanguageSettings | undefined>;
-	getCustomData?(context: ServiceContext): Promise<css.ICSSDataProvider[]>;
+	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Result<boolean>;
+	getFormatConfiguration?(document: TextDocument, context: ServiceContext): Result<css.CSSFormatConfiguration | undefined>;
+	getLanguageSettings?(document: TextDocument, context: ServiceContext): Result<css.LanguageSettings | undefined>;
+	getCustomData?(context: ServiceContext): Result<css.ICSSDataProvider[]>;
 	onDidChangeCustomData?(listener: () => void, context: ServiceContext): Disposable;
 } = {}): ServicePlugin {
 	return {

--- a/packages/emmet/index.ts
+++ b/packages/emmet/index.ts
@@ -1,6 +1,28 @@
-import type { ServicePluginInstance, ServicePlugin } from '@volar/language-service';
+import type { ServicePluginInstance, ServicePlugin, TextDocument } from '@volar/language-service';
 import * as emmet from '@vscode/emmet-helper';
-import { getHtmlDocument } from 'volar-service-html';
+import * as html from 'vscode-html-languageservice';
+
+const htmlDocuments = new WeakMap<TextDocument, [number, html.HTMLDocument]>();
+
+let htmlLs: html.LanguageService;
+
+function getHtmlDocument(document: TextDocument) {
+
+	const cache = htmlDocuments.get(document);
+	if (cache) {
+		const [cacheVersion, cacheDoc] = cache;
+		if (cacheVersion === document.version) {
+			return cacheDoc;
+		}
+	}
+
+	htmlLs ??= html.getLanguageService();
+
+	const doc = htmlLs.parseHTMLDocument(document);
+	htmlDocuments.set(document, [document.version, doc]);
+
+	return doc;
+}
 
 export function create(): ServicePlugin {
 	return {

--- a/packages/emmet/package.json
+++ b/packages/emmet/package.json
@@ -25,7 +25,7 @@
 	},
 	"dependencies": {
 		"@vscode/emmet-helper": "^2.9.2",
-		"volar-service-html": "0.0.30"
+		"vscode-html-languageservice": "^5.1.0"
 	},
 	"peerDependencies": {
 		"@volar/language-service": "~2.1.0"

--- a/packages/html/index.ts
+++ b/packages/html/index.ts
@@ -1,4 +1,4 @@
-import type { ServicePluginInstance, ServicePlugin, DocumentSelector, ServiceContext, Disposable } from '@volar/language-service';
+import type { Disposable, DocumentSelector, Result, ServiceContext, ServicePlugin, ServicePluginInstance } from '@volar/language-service';
 import * as html from 'vscode-html-languageservice';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI, Utils } from 'vscode-uri';
@@ -81,14 +81,14 @@ export function create({
 	documentSelector?: DocumentSelector;
 	useDefaultDataProvider?: boolean;
 	useCustomDataProviders?: boolean;
-	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
-	isAutoCreateQuotesEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
-	isAutoClosingTagsEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
+	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Result<boolean>;
+	isAutoCreateQuotesEnabled?(document: TextDocument, context: ServiceContext): Result<boolean>;
+	isAutoClosingTagsEnabled?(document: TextDocument, context: ServiceContext): Result<boolean>;
 	getDocumentContext?(context: ServiceContext): html.DocumentContext;
-	getFormattingOptions?(document: TextDocument, context: ServiceContext): Promise<html.HTMLFormatConfiguration | undefined>;
-	getCompletionConfiguration?(document: TextDocument, context: ServiceContext): Promise<html.CompletionConfiguration | undefined>;
-	getHoverSettings?(document: TextDocument, context: ServiceContext): Promise<html.HoverSettings | undefined>;
-	getCustomData?(context: ServiceContext): Promise<html.IHTMLDataProvider[]>;
+	getFormattingOptions?(document: TextDocument, context: ServiceContext): Result<html.HTMLFormatConfiguration | undefined>;
+	getCompletionConfiguration?(document: TextDocument, context: ServiceContext): Result<html.CompletionConfiguration | undefined>;
+	getHoverSettings?(document: TextDocument, context: ServiceContext): Result<html.HoverSettings | undefined>;
+	getCustomData?(context: ServiceContext): Result<html.IHTMLDataProvider[]>;
 	onDidChangeCustomData?(listener: () => void, context: ServiceContext): Disposable;
 } = {}): ServicePlugin {
 	return {

--- a/packages/html/index.ts
+++ b/packages/html/index.ts
@@ -1,89 +1,137 @@
-import type { ServicePluginInstance, ServicePlugin } from '@volar/language-service';
+import type { ServicePluginInstance, ServicePlugin, DocumentSelector, ServiceContext, Disposable } from '@volar/language-service';
 import * as html from 'vscode-html-languageservice';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI, Utils } from 'vscode-uri';
 
-const parserLs = html.getLanguageService();
-const htmlDocuments = new WeakMap<TextDocument, [number, html.HTMLDocument]>();
 
 export interface Provide {
 	'html/htmlDocument': (document: TextDocument) => html.HTMLDocument | undefined;
 	'html/languageService': () => html.LanguageService;
 	'html/documentContext': () => html.DocumentContext;
-	'html/updateCustomData': (extraData: html.IHTMLDataProvider[]) => void;
-}
-
-export function getHtmlDocument(document: TextDocument) {
-
-	const cache = htmlDocuments.get(document);
-	if (cache) {
-		const [cacheVersion, cacheDoc] = cache;
-		if (cacheVersion === document.version) {
-			return cacheDoc;
-		}
-	}
-
-	const doc = parserLs.parseHTMLDocument(document);
-	htmlDocuments.set(document, [document.version, doc]);
-
-	return doc;
 }
 
 export function create({
-	languageId = 'html',
+	documentSelector = ['html'],
 	useDefaultDataProvider = true,
-	useCustomDataProviders = true,
+	getDocumentContext = context => {
+		return {
+			resolveReference(ref, base) {
+				if (ref.match(/^\w[\w\d+.-]*:/)) {
+					// starts with a schema
+					return ref;
+				}
+				if (ref[0] === '/') { // resolve absolute path against the current workspace folder
+					let folderUri = context.env.workspaceFolder;
+					if (!folderUri.endsWith('/')) {
+						folderUri += '/';
+					}
+					return folderUri + ref.substring(1);
+				}
+				const baseUri = URI.parse(base);
+				const baseUriDir = baseUri.path.endsWith('/') ? baseUri : Utils.dirname(baseUri);
+				return Utils.resolvePath(baseUriDir, ref).toString(true);
+			},
+		};
+	},
+	isFormattingEnabled = async (_document, context) => {
+		return await context.env.getConfiguration?.('html.format.enable') ?? true;
+	},
+	isAutoCreateQuotesEnabled = async (_document, context) => {
+		return await context.env.getConfiguration?.('html.autoCreateQuotes') ?? true;
+	},
+	isAutoClosingTagsEnabled = async (_document, context) => {
+		return await context.env.getConfiguration?.('html.autoClosingTags') ?? true;
+	},
+	getFormattingOptions = async (_document, context) => {
+		return await context.env.getConfiguration?.('html.format');
+	},
+	getCompletionConfiguration = async (_document, context) => {
+		return await context.env.getConfiguration?.('html.completion');
+	},
+	getHoverSettings = async (_document, context) => {
+		return await context.env.getConfiguration?.('html.hover');
+	},
+	getCustomData = async context => {
+		const customData: string[] = await context.env.getConfiguration?.('html.customData') ?? [];
+		const newData: html.IHTMLDataProvider[] = [];
+		for (const customDataPath of customData) {
+			const uri = Utils.resolvePath(URI.parse(context.env.workspaceFolder), customDataPath);
+			const json = await context.env.fs?.readFile?.(uri.toString());
+			if (json) {
+				try {
+					const data = JSON.parse(json);
+					newData.push(html.newHTMLDataProvider(customDataPath, data));
+				}
+				catch (error) {
+					console.error(error);
+				}
+			}
+		}
+		return newData;
+	},
+	onDidChangeCustomData = (listener, context) => {
+		const disposable = context.env.onDidChangeConfiguration?.(listener);
+		return {
+			dispose() {
+				disposable?.dispose();
+			},
+		};
+	},
 }: {
-	languageId?: string;
+	documentSelector?: DocumentSelector;
 	useDefaultDataProvider?: boolean;
 	useCustomDataProviders?: boolean;
+	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
+	isAutoCreateQuotesEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
+	isAutoClosingTagsEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
+	getDocumentContext?(context: ServiceContext): html.DocumentContext;
+	getFormattingOptions?(document: TextDocument, context: ServiceContext): Promise<html.FormattingOptions | undefined>;
+	getCompletionConfiguration?(document: TextDocument, context: ServiceContext): Promise<html.CompletionConfiguration | undefined>;
+	getHoverSettings?(document: TextDocument, context: ServiceContext): Promise<html.HoverSettings | undefined>;
+	getCustomData?(context: ServiceContext): Promise<html.IHTMLDataProvider[]>;
+	onDidChangeCustomData?(listener: () => void, context: ServiceContext): Disposable;
 } = {}): ServicePlugin {
 	return {
 		name: 'html',
 		// https://github.com/microsoft/vscode/blob/09850876e652688fb142e2e19fd00fd38c0bc4ba/extensions/html-language-features/server/src/htmlServer.ts#L183
 		triggerCharacters: ['.', ':', '<', '"', '=', '/'],
 		create(context): ServicePluginInstance<Provide> {
-			let shouldUpdateCustomData = true;
-			let customData: html.IHTMLDataProvider[] = [];
-			let extraData: html.IHTMLDataProvider[] = [];
 
+			const htmlDocuments = new WeakMap<TextDocument, [number, html.HTMLDocument]>();
 			const fileSystemProvider: html.FileSystemProvider = {
-				stat: async uri => await context.env.fs?.stat(uri) ?? {
-					type: html.FileType.Unknown,
-					ctime: 0,
-					mtime: 0,
-					size: 0,
-				},
+				stat: async uri => await context.env.fs?.stat(uri)
+					?? { type: html.FileType.Unknown, ctime: 0, mtime: 0, size: 0 },
 				readDirectory: async (uri) => context.env.fs?.readDirectory(uri) ?? [],
 			};
-			const documentContext = getDocumentContext(context.env.workspaceFolder);
+			const documentContext = getDocumentContext(context);
 			const htmlLs = html.getLanguageService({
 				fileSystemProvider,
 				clientCapabilities: context.env.clientCapabilities,
+				useDefaultDataProvider,
 			});
+			const disposable = onDidChangeCustomData(() => initializing = undefined, context);
 
-			context.env.onDidChangeConfiguration?.(() => {
-				shouldUpdateCustomData = true;
-			});
+			let initializing: Promise<void> | undefined;
 
 			return {
 
+				dispose() {
+					disposable.dispose();
+				},
+
 				provide: {
 					'html/htmlDocument': (document) => {
-						if (document.languageId === languageId) {
+						if (matchDocument(documentSelector, document)) {
 							return getHtmlDocument(document);
 						}
 					},
 					'html/languageService': () => htmlLs,
 					'html/documentContext': () => documentContext,
-					'html/updateCustomData': updateExtraCustomData,
 				},
 
 				async provideCompletionItems(document, position) {
 					return worker(document, async (htmlDocument) => {
-
-						const configs = await context.env.getConfiguration?.<html.CompletionConfiguration>('html.completion');
-
+						const configs = await getCompletionConfiguration(document, context);
 						return htmlLs.doComplete2(document, position, htmlDocument, documentContext, configs);
 					});
 				},
@@ -106,9 +154,7 @@ export function create({
 
 				async provideHover(document, position) {
 					return worker(document, async (htmlDocument) => {
-
-						const hoverSettings = await context.env.getConfiguration?.<html.HoverSettings>('html.hover');
-
+						const hoverSettings = await getHoverSettings(document, context);
 						return htmlLs.doHover(document, position, htmlDocument, hoverSettings);
 					});
 				},
@@ -146,16 +192,8 @@ export function create({
 				async provideDocumentFormattingEdits(document, formatRange, options, codeOptions) {
 					return worker(document, async () => {
 
-						const formatSettings = await context.env.getConfiguration?.<html.HTMLFormatConfiguration & { enable?: boolean; }>('html.format') ?? {};
-						if (formatSettings.enable === false) {
+						if (!await isFormattingEnabled(document, context)) {
 							return;
-						}
-
-						// https://github.com/microsoft/vscode/blob/a8f73340be02966c3816a2f23cb7e446a3a7cb9b/extensions/html-language-features/server/src/modes/htmlMode.ts#L47-L51
-						if (formatSettings.contentUnformatted) {
-							formatSettings.contentUnformatted = formatSettings.contentUnformatted + ',script';
-						} else {
-							formatSettings.contentUnformatted = 'script';
 						}
 
 						// https://github.com/microsoft/vscode/blob/dce493cb6e36346ef2714e82c42ce14fc461b15c/extensions/html-language-features/server/src/modes/formatting.ts#L13-L23
@@ -174,6 +212,7 @@ export function create({
 							};
 						}
 
+						const formatSettings = await getFormattingOptions(document, context);
 						const formatOptions: html.HTMLFormatConfiguration = {
 							...options,
 							...formatSettings,
@@ -287,11 +326,12 @@ export function create({
 
 						if (rangeLengthIsZero && lastCharacter === '=') {
 
-							const enabled = (await context.env.getConfiguration?.<boolean>('html.autoCreateQuotes')) ?? true;
+							const enabled = await isAutoCreateQuotesEnabled(document, context);
 
 							if (enabled) {
 
-								const text = htmlLs.doQuoteComplete(document, position, htmlDocument, await context.env.getConfiguration?.<html.CompletionConfiguration>('html.completion'));
+								const completionConfiguration = await getCompletionConfiguration(document, context);
+								const text = htmlLs.doQuoteComplete(document, position, htmlDocument, completionConfiguration);
 
 								if (text) {
 									return text;
@@ -301,7 +341,7 @@ export function create({
 
 						if (rangeLengthIsZero && (lastCharacter === '>' || lastCharacter === '/')) {
 
-							const enabled = (await context.env.getConfiguration?.<boolean>('html.autoClosingTags')) ?? true;
+							const enabled = await isAutoClosingTagsEnabled(document, context);
 
 							if (enabled) {
 
@@ -316,76 +356,42 @@ export function create({
 				},
 			};
 
-			async function initCustomData() {
-				if (shouldUpdateCustomData && useCustomDataProviders) {
-					shouldUpdateCustomData = false;
-					customData = await getCustomData();
-					htmlLs.setDataProviders(useDefaultDataProvider, [...customData, ...extraData]);
-				}
-			}
+			function getHtmlDocument(document: TextDocument) {
 
-			function updateExtraCustomData(data: html.IHTMLDataProvider[]) {
-				extraData = data;
-				htmlLs.setDataProviders(useDefaultDataProvider, [...customData, ...extraData]);
-			}
-
-			async function getCustomData() {
-
-				const customData: string[] = await context.env.getConfiguration?.('html.customData') ?? [];
-				const newData: html.IHTMLDataProvider[] = [];
-
-				for (const customDataPath of customData) {
-					try {
-						const pathModuleName = 'path'; // avoid bundle
-						const { posix: path } = require(pathModuleName) as typeof import('path');
-						const jsonPath = path.resolve(customDataPath);
-						newData.push(html.newHTMLDataProvider(customDataPath, require(jsonPath)));
-					}
-					catch (error) {
-						console.error(error);
+				const cache = htmlDocuments.get(document);
+				if (cache) {
+					const [cacheVersion, cacheDoc] = cache;
+					if (cacheVersion === document.version) {
+						return cacheDoc;
 					}
 				}
 
-				return newData;
+				const doc = htmlLs.parseHTMLDocument(document);
+				htmlDocuments.set(document, [document.version, doc]);
+
+				return doc;
 			}
 
 			async function worker<T>(document: TextDocument, callback: (htmlDocument: html.HTMLDocument) => T) {
 
-				if (document.languageId !== languageId)
+				if (!matchDocument(documentSelector, document))
 					return;
 
 				const htmlDocument = getHtmlDocument(document);
 				if (!htmlDocument)
 					return;
 
-				await initCustomData();
+				await (initializing ??= initialize());
 
 				return callback(htmlDocument);
 			}
-		},
-	};
-}
 
-export function getDocumentContext(workspaceFolder: string) {
-	const documentContext: html.DocumentContext = {
-		resolveReference(ref, base) {
-			if (ref.match(/^\w[\w\d+.-]*:/)) {
-				// starts with a schema
-				return ref;
+			async function initialize() {
+				const customData = await getCustomData(context);
+				htmlLs.setDataProviders(useDefaultDataProvider, customData);
 			}
-			if (ref[0] === '/') { // resolve absolute path against the current workspace folder
-				let folderUri = workspaceFolder;
-				if (!folderUri.endsWith('/')) {
-					folderUri += '/';
-				}
-				return folderUri + ref.substr(1);
-			}
-			const baseUri = URI.parse(base);
-			const baseUriDir = baseUri.path.endsWith('/') ? baseUri : Utils.dirname(baseUri);
-			return Utils.resolvePath(baseUriDir, ref).toString(true);
 		},
 	};
-	return documentContext;
 }
 
 function isEOL(content: string, offset: number) {
@@ -396,4 +402,13 @@ const CR = '\r'.charCodeAt(0);
 const NL = '\n'.charCodeAt(0);
 function isNewlineCharacter(charCode: number) {
 	return charCode === CR || charCode === NL;
+}
+
+function matchDocument(selector: DocumentSelector, document: TextDocument) {
+	for (const sel of selector) {
+		if (sel === document.languageId || (typeof sel === 'object' && sel.language === document.languageId)) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/packages/json/index.ts
+++ b/packages/json/index.ts
@@ -1,4 +1,4 @@
-import type { ServicePlugin, Diagnostic, ServicePluginInstance } from '@volar/language-service';
+import type { ServicePlugin, ServicePluginInstance, DocumentSelector, ServiceContext, Disposable } from '@volar/language-service';
 import * as json from 'vscode-json-languageservice';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI, Utils } from 'vscode-uri';
@@ -8,7 +8,71 @@ export interface Provide {
 	'json/languageService': () => json.LanguageService;
 }
 
-export function create(settings?: json.LanguageSettings): ServicePlugin {
+export interface JSONSchemaSettings {
+	fileMatch?: string[];
+	url?: string;
+	schema?: json.JSONSchema;
+	folderUri?: string;
+}
+
+export function create({
+	documentSelector = ['json', 'jsonc'],
+	getWorkspaceContextService = () => {
+		return {
+			resolveRelativePath(relativePath, resource) {
+				const base = resource.substring(0, resource.lastIndexOf('/') + 1);
+				return Utils.resolvePath(URI.parse(base), relativePath).toString();
+			},
+		};
+	},
+	isFormattingEnabled = async (_document, context) => {
+		return await context.env.getConfiguration?.('json.format.enable') ?? true;
+	},
+	getFormattingOptions = async (_document, context) => {
+		return await context.env.getConfiguration?.('json.format');
+	},
+	getLanguageSettings = async context => {
+		const languageSettings: json.LanguageSettings = {};
+
+		languageSettings.validate = await context.env.getConfiguration?.<boolean>('json.validate') ?? true;
+		languageSettings.schemas ??= [];
+
+		const schemas = await context.env.getConfiguration?.<JSONSchemaSettings[]>('json.schemas') ?? [];
+
+		for (let i = 0; i < schemas.length; i++) {
+			const schema = schemas[i];
+			let uri = schema.url;
+			if (!uri && schema.schema) {
+				uri = schema.schema.id || `vscode://schemas/custom/${i}`;
+			}
+			if (uri) {
+				languageSettings.schemas.push({ uri, fileMatch: schema.fileMatch, schema: schema.schema, folderUri: schema.folderUri });
+			}
+		}
+		return languageSettings;
+	},
+	getDocumentLanguageSettings = async document => {
+		return document.languageId === 'jsonc'
+			? { comments: 'ignore', trailingCommas: 'warning' }
+			: { comments: 'error', trailingCommas: 'error' };
+	},
+	onDidChangeLanguageSettings = (listener, context) => {
+		const disposable = context.env.onDidChangeConfiguration?.(listener);
+		return {
+			dispose() {
+				disposable?.dispose();
+			},
+		};
+	},
+}: {
+	documentSelector?: DocumentSelector;
+	getWorkspaceContextService?(context: ServiceContext): json.WorkspaceContextService;
+	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
+	getFormattingOptions?(document: TextDocument, context: ServiceContext): Promise<json.FormattingOptions | undefined>;
+	getLanguageSettings?(context: ServiceContext): Promise<json.LanguageSettings>;
+	getDocumentLanguageSettings?(document: TextDocument, context: ServiceContext): Promise<json.DocumentLanguageSettings | undefined>;
+	onDidChangeLanguageSettings?(listener: () => void, context: ServiceContext): Disposable;
+} = {}): ServicePlugin {
 	return {
 		name: 'json',
 		// https://github.com/microsoft/vscode/blob/09850876e652688fb142e2e19fd00fd38c0bc4ba/extensions/json-language-features/server/src/jsonServer.ts#L150
@@ -16,31 +80,20 @@ export function create(settings?: json.LanguageSettings): ServicePlugin {
 		create(context): ServicePluginInstance<Provide> {
 
 			const jsonDocuments = new WeakMap<TextDocument, [number, json.JSONDocument]>();
-			const workspaceContext: json.WorkspaceContextService = {
-				resolveRelativePath: (ref: string, base: string) => {
-					if (ref.match(/^\w[\w\d+.-]*:/)) {
-						// starts with a schema
-						return ref;
-					}
-					if (ref[0] === '/') { // resolve absolute path against the current workspace folder
-						return base + ref;
-					}
-					const baseUri = URI.parse(base);
-					const baseUriDir = baseUri.path.endsWith('/') ? baseUri : Utils.dirname(baseUri);
-					return Utils.resolvePath(baseUriDir, ref).toString(true);
-				},
-			};
 			const jsonLs = json.getLanguageService({
 				schemaRequestService: async (uri) => await context.env.fs?.readFile(uri) ?? '',
-				workspaceContext,
+				workspaceContext: getWorkspaceContextService(context),
 				clientCapabilities: context.env.clientCapabilities,
 			});
+			const disposable = onDidChangeLanguageSettings(() => initializing = undefined, context);
 
-			if (settings) {
-				jsonLs.configure(settings);
-			}
+			let initializing: Promise<void> | undefined;
 
 			return {
+
+				dispose() {
+					disposable.dispose();
+				},
 
 				provide: {
 					'json/jsonDocument': getJsonDocument,
@@ -65,15 +118,8 @@ export function create(settings?: json.LanguageSettings): ServicePlugin {
 
 				provideDiagnostics(document) {
 					return worker(document, async (jsonDocument) => {
-
-						const documentLanguageSettings = undefined; // await getSettings(); // TODO
-
-						return await jsonLs.doValidation(
-							document,
-							jsonDocument,
-							documentLanguageSettings,
-							undefined, // TODO
-						) as Diagnostic[];
+						const settings = await getDocumentLanguageSettings(document, context);
+						return await jsonLs.doValidation(document, jsonDocument, settings);
 					});
 				},
 
@@ -122,32 +168,41 @@ export function create(settings?: json.LanguageSettings): ServicePlugin {
 				provideDocumentFormattingEdits(document, range, options) {
 					return worker(document, async () => {
 
-						const options_2 = await context.env.getConfiguration?.<json.FormattingOptions & { enable: boolean; }>('json.format');
-						if (!(options_2?.enable ?? true)) {
+						if (!await isFormattingEnabled(document, context)) {
 							return;
 						}
 
+						const formatOptions = await getFormattingOptions(document, context);
+
 						return jsonLs.format(document, range, {
-							...options_2,
 							...options,
+							...formatOptions,
 						});
 					});
 				},
 			};
 
-			function worker<T>(document: TextDocument, callback: (jsonDocument: json.JSONDocument) => T) {
+			async function worker<T>(document: TextDocument, callback: (jsonDocument: json.JSONDocument) => T): Promise<Awaited<T> | undefined> {
 
 				const jsonDocument = getJsonDocument(document);
 				if (!jsonDocument)
 					return;
 
-				return callback(jsonDocument);
+				await (initializing ??= initialize());
+
+				return await callback(jsonDocument);
+			}
+
+			async function initialize() {
+				const settings = await getLanguageSettings(context);
+				jsonLs.configure(settings);
 			}
 
 			function getJsonDocument(textDocument: TextDocument) {
 
-				if (textDocument.languageId !== 'json' && textDocument.languageId !== 'jsonc')
+				if (!matchDocument(documentSelector, textDocument)) {
 					return;
+				}
 
 				const cache = jsonDocuments.get(textDocument);
 				if (cache) {
@@ -164,4 +219,13 @@ export function create(settings?: json.LanguageSettings): ServicePlugin {
 			}
 		},
 	};
+}
+
+function matchDocument(selector: DocumentSelector, document: TextDocument) {
+	for (const sel of selector) {
+		if (sel === document.languageId || (typeof sel === 'object' && sel.language === document.languageId)) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/packages/json/index.ts
+++ b/packages/json/index.ts
@@ -1,4 +1,4 @@
-import type { ServicePlugin, ServicePluginInstance, DocumentSelector, ServiceContext, Disposable } from '@volar/language-service';
+import type { ServicePlugin, ServicePluginInstance, DocumentSelector, ServiceContext, Disposable, Result } from '@volar/language-service';
 import * as json from 'vscode-json-languageservice';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import { URI, Utils } from 'vscode-uri';
@@ -51,7 +51,7 @@ export function create({
 		}
 		return languageSettings;
 	},
-	getDocumentLanguageSettings = async document => {
+	getDocumentLanguageSettings = document => {
 		return document.languageId === 'jsonc'
 			? { comments: 'ignore', trailingCommas: 'warning' }
 			: { comments: 'error', trailingCommas: 'error' };
@@ -67,10 +67,10 @@ export function create({
 }: {
 	documentSelector?: DocumentSelector;
 	getWorkspaceContextService?(context: ServiceContext): json.WorkspaceContextService;
-	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
-	getFormattingOptions?(document: TextDocument, context: ServiceContext): Promise<json.FormattingOptions | undefined>;
-	getLanguageSettings?(context: ServiceContext): Promise<json.LanguageSettings>;
-	getDocumentLanguageSettings?(document: TextDocument, context: ServiceContext): Promise<json.DocumentLanguageSettings | undefined>;
+	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Result<boolean>;
+	getFormattingOptions?(document: TextDocument, context: ServiceContext): Result<json.FormattingOptions | undefined>;
+	getLanguageSettings?(context: ServiceContext): Result<json.LanguageSettings>;
+	getDocumentLanguageSettings?(document: TextDocument, context: ServiceContext): Result<json.DocumentLanguageSettings | undefined>;
 	onDidChangeLanguageSettings?(listener: () => void, context: ServiceContext): Disposable;
 } = {}): ServicePlugin {
 	return {

--- a/packages/markdown/index.ts
+++ b/packages/markdown/index.ts
@@ -1,4 +1,5 @@
-import { ServicePluginInstance, forEachEmbeddedCode, type FileChangeType, type FileType, type LocationLink, type ServicePlugin, ServiceContext, DocumentSelector } from '@volar/language-service';
+import type { DocumentSelector, FileChangeType, FileType, LocationLink, Result, ServiceContext, ServicePlugin, ServicePluginInstance } from '@volar/language-service';
+import { forEachEmbeddedCode } from '@volar/language-service';
 import { Emitter } from 'vscode-jsonrpc';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { DiagnosticOptions, ILogger, IMdLanguageService, IMdParser, IWorkspace } from 'vscode-markdown-languageservice';
@@ -25,7 +26,7 @@ export function create({
 	},
 }: {
 	documentSelector?: DocumentSelector;
-	getDiagnosticOptions?(document: TextDocument, context: ServiceContext): Promise<DiagnosticOptions | undefined>;
+	getDiagnosticOptions?(document: TextDocument, context: ServiceContext): Result<DiagnosticOptions | undefined>;
 } = {}): ServicePlugin {
 	return {
 		name: 'markdown',

--- a/packages/prettyhtml/index.ts
+++ b/packages/prettyhtml/index.ts
@@ -1,21 +1,34 @@
-import type { ServicePluginInstance, ServicePlugin } from '@volar/language-service';
+import type { ServicePluginInstance, ServicePlugin, DocumentSelector, TextDocument, ServiceContext } from '@volar/language-service';
 import * as prettyhtml from '@starptech/prettyhtml';
 
-export function create(configs: NonNullable<Parameters<typeof prettyhtml>[1]>): ServicePlugin {
+export type FormattingOptions = Parameters<typeof prettyhtml>[1];
+
+export function create({
+	documentSelector = ['html'],
+	isFormattingEnabled = async () => true,
+	getFormattingOptions = async () => ({}),
+}: {
+	documentSelector?: DocumentSelector;
+	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
+	getFormattingOptions?(document: TextDocument, context: ServiceContext): Promise<FormattingOptions>;
+} = {}): ServicePlugin {
 	return {
 		name: 'prettyhtml',
-		create(): ServicePluginInstance {
+		create(context): ServicePluginInstance {
 			return {
-				provideDocumentFormattingEdits(document, range, options) {
+				async provideDocumentFormattingEdits(document, range, options) {
 
-					if (document.languageId !== 'html')
+					if (!matchDocument(documentSelector, document))
+						return;
+
+					if (!await isFormattingEnabled(document, context))
 						return;
 
 					const oldRangeText = document.getText(range);
 					const newRangeText = prettyhtml(oldRangeText, {
-						...configs,
 						tabWidth: options.tabSize,
 						useTabs: !options.insertSpaces,
+						...await getFormattingOptions(document, context),
 					}).contents;
 
 					if (newRangeText === oldRangeText)
@@ -42,4 +55,13 @@ export function create(configs: NonNullable<Parameters<typeof prettyhtml>[1]>): 
 			};
 		},
 	};
+}
+
+function matchDocument(selector: DocumentSelector, document: TextDocument) {
+	for (const sel of selector) {
+		if (sel === document.languageId || (typeof sel === 'object' && sel.language === document.languageId)) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/packages/prettyhtml/index.ts
+++ b/packages/prettyhtml/index.ts
@@ -1,16 +1,16 @@
-import type { ServicePluginInstance, ServicePlugin, DocumentSelector, TextDocument, ServiceContext } from '@volar/language-service';
 import * as prettyhtml from '@starptech/prettyhtml';
+import type { DocumentSelector, Result, ServiceContext, ServicePlugin, ServicePluginInstance, TextDocument } from '@volar/language-service';
 
 export type FormattingOptions = Parameters<typeof prettyhtml>[1];
 
 export function create({
 	documentSelector = ['html'],
-	isFormattingEnabled = async () => true,
-	getFormattingOptions = async () => ({}),
+	isFormattingEnabled = () => true,
+	getFormattingOptions = () => ({}),
 }: {
 	documentSelector?: DocumentSelector;
-	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
-	getFormattingOptions?(document: TextDocument, context: ServiceContext): Promise<FormattingOptions>;
+	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Result<boolean>;
+	getFormattingOptions?(document: TextDocument, context: ServiceContext): Result<FormattingOptions>;
 } = {}): ServicePlugin {
 	return {
 		name: 'prettyhtml',

--- a/packages/pug-beautify/index.ts
+++ b/packages/pug-beautify/index.ts
@@ -1,13 +1,11 @@
-import type { ServicePluginInstance, ServicePlugin, DocumentSelector, TextDocument, ServiceContext } from '@volar/language-service';
+import type { DocumentSelector, Result, ServiceContext, ServicePlugin, ServicePluginInstance, TextDocument } from '@volar/language-service';
 
 export function create({
 	documentSelector = ['jade'],
-	isFormattingEnabled = async () => {
-		return true;
-	},
+	isFormattingEnabled = () => true,
 }: {
 	documentSelector?: DocumentSelector;
-	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
+	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Result<boolean>;
 } = {}): ServicePlugin {
 	return {
 		name: 'pug-beautify',

--- a/packages/pug/index.ts
+++ b/packages/pug/index.ts
@@ -1,4 +1,5 @@
-import { transformDocumentSymbol, type Diagnostic, type DiagnosticSeverity, type Disposable, type DocumentSelector, type ServiceContext, type ServicePlugin, type ServicePluginInstance } from '@volar/language-service';
+import type { Diagnostic, DiagnosticSeverity, Disposable, DocumentSelector, Result, ServiceContext, ServicePlugin, ServicePluginInstance } from '@volar/language-service';
+import { transformDocumentSymbol } from '@volar/language-service';
 import { create as createHtmlService } from 'volar-service-html';
 import type * as html from 'vscode-html-languageservice';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
@@ -15,7 +16,7 @@ export function create({
 	onDidChangeCustomData,
 }: {
 	documentSelector?: DocumentSelector;
-	getCustomData?(context: ServiceContext): Promise<html.IHTMLDataProvider[]>;
+	getCustomData?(context: ServiceContext): Result<html.IHTMLDataProvider[]>;
 	onDidChangeCustomData?(listener: () => void, context: ServiceContext): Disposable;
 } = {}): ServicePlugin {
 	const _htmlService = createHtmlService({

--- a/packages/pug/index.ts
+++ b/packages/pug/index.ts
@@ -1,4 +1,4 @@
-import { transformDocumentSymbol, type Diagnostic, type DiagnosticSeverity, type ServicePlugin, ServicePluginInstance } from '@volar/language-service';
+import { transformDocumentSymbol, type Diagnostic, type DiagnosticSeverity, type Disposable, type DocumentSelector, type ServiceContext, type ServicePlugin, type ServicePluginInstance } from '@volar/language-service';
 import { create as createHtmlService } from 'volar-service-html';
 import type * as html from 'vscode-html-languageservice';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
@@ -7,11 +7,21 @@ import * as pug from './lib/languageService';
 export interface Provide {
 	'pug/pugDocument': (document: TextDocument) => pug.PugDocument | undefined;
 	'pug/languageService': () => pug.LanguageService;
-	'pug/updateCustomData': (extraData: html.IHTMLDataProvider[]) => void;
 }
 
-export function create(): ServicePlugin {
-	const _htmlService = createHtmlService();
+export function create({
+	documentSelector = ['jade'],
+	getCustomData,
+	onDidChangeCustomData,
+}: {
+	documentSelector?: DocumentSelector;
+	getCustomData?(context: ServiceContext): Promise<html.IHTMLDataProvider[]>;
+	onDidChangeCustomData?(listener: () => void, context: ServiceContext): Disposable;
+} = {}): ServicePlugin {
+	const _htmlService = createHtmlService({
+		getCustomData,
+		onDidChangeCustomData,
+	});
 	return {
 		..._htmlService,
 		name: 'pug',
@@ -27,7 +37,6 @@ export function create(): ServicePlugin {
 				provide: {
 					'pug/pugDocument': getPugDocument,
 					'pug/languageService': () => pugLs,
-					'pug/updateCustomData': htmlService.provide['html/updateCustomData'],
 				},
 
 				provideCompletionItems(document, position, _) {
@@ -138,7 +147,7 @@ export function create(): ServicePlugin {
 
 			function getPugDocument(document: TextDocument) {
 
-				if (document.languageId !== 'jade')
+				if (!matchDocument(documentSelector, document))
 					return;
 
 				const cache = pugDocuments.get(document);
@@ -156,4 +165,13 @@ export function create(): ServicePlugin {
 			}
 		},
 	};
+}
+
+function matchDocument(selector: DocumentSelector, document: TextDocument) {
+	for (const sel of selector) {
+		if (sel === document.languageId || (typeof sel === 'object' && sel.language === document.languageId)) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/packages/sass-formatter/index.ts
+++ b/packages/sass-formatter/index.ts
@@ -1,31 +1,51 @@
-import type { ServicePluginInstance, ServicePlugin } from '@volar/language-service';
-import { SassFormatter } from 'sass-formatter';
+import type { ServicePluginInstance, ServicePlugin, DocumentSelector, TextDocument, ServiceContext } from '@volar/language-service';
+import { SassFormatter, SassFormatterConfig } from 'sass-formatter';
 
-export function create(configs: Parameters<typeof SassFormatter.Format>[1]): ServicePlugin {
+export function create({
+	documentSelector = ['sass'],
+	isFormattingEnabled = async () => true,
+	getFormatterConfig,
+}: {
+	documentSelector?: DocumentSelector;
+	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
+	getFormatterConfig?(document: TextDocument): Promise<SassFormatterConfig>;
+} = {}): ServicePlugin {
 	return {
 		name: 'sass-formatter',
-		create(): ServicePluginInstance {
+		create(context): ServicePluginInstance {
 			return {
-				provideDocumentFormattingEdits(document, range, options) {
+				async provideDocumentFormattingEdits(document, range, options) {
 
-					if (document.languageId !== 'sass')
+					if (!matchDocument(documentSelector, document))
 						return;
 
-					const _options: typeof configs = {
-						...configs,
-						insertSpaces: options.insertSpaces,
+					if (!await isFormattingEnabled(document, context))
+						return;
+
+					const config = {
+						...options,
+						...getFormatterConfig ? await getFormatterConfig(document) : {},
 					};
 
 					// don't set when options.insertSpaces is false to avoid sass-formatter internal judge bug
-					if (options.insertSpaces)
-						_options.tabSize = options.tabSize;
+					if (config.insertSpaces)
+						config.tabSize = options.tabSize;
 
 					return [{
-						newText: SassFormatter.Format(document.getText(), _options),
+						newText: SassFormatter.Format(document.getText(), config),
 						range: range,
 					}];
 				},
 			};
 		},
 	};
+}
+
+function matchDocument(selector: DocumentSelector, document: TextDocument) {
+	for (const sel of selector) {
+		if (sel === document.languageId || (typeof sel === 'object' && sel.language === document.languageId)) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/packages/sass-formatter/index.ts
+++ b/packages/sass-formatter/index.ts
@@ -1,14 +1,14 @@
-import type { ServicePluginInstance, ServicePlugin, DocumentSelector, TextDocument, ServiceContext } from '@volar/language-service';
+import type { DocumentSelector, Result, ServiceContext, ServicePlugin, ServicePluginInstance, TextDocument } from '@volar/language-service';
 import { SassFormatter, SassFormatterConfig } from 'sass-formatter';
 
 export function create({
 	documentSelector = ['sass'],
-	isFormattingEnabled = async () => true,
+	isFormattingEnabled = () => true,
 	getFormatterConfig,
 }: {
 	documentSelector?: DocumentSelector;
-	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
-	getFormatterConfig?(document: TextDocument): Promise<SassFormatterConfig>;
+	isFormattingEnabled?(document: TextDocument, context: ServiceContext): Result<boolean>;
+	getFormatterConfig?(document: TextDocument): Result<SassFormatterConfig>;
 } = {}): ServicePlugin {
 	return {
 		name: 'sass-formatter',

--- a/packages/typescript/index.ts
+++ b/packages/typescript/index.ts
@@ -1,4 +1,4 @@
-import type { CancellationToken, CompletionList, CompletionTriggerKind, FileChangeType, ServicePluginInstance, ServicePlugin, VirtualCode, ServiceContext } from '@volar/language-service';
+import type { CancellationToken, CompletionList, CompletionTriggerKind, FileChangeType, Result, ServiceContext, ServicePlugin, ServicePluginInstance, VirtualCode } from '@volar/language-service';
 import * as semver from 'semver';
 import type * as ts from 'typescript';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
@@ -60,10 +60,10 @@ export function create(
 			return await context.env.getConfiguration?.<boolean>(getConfigTitle(document) + '.autoClosingTags') ?? true;
 		},
 	}: {
-		isFormattingEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
-		isValidationEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
-		isSuggestionsEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
-		isAutoClosingTagsEnabled?(document: TextDocument, context: ServiceContext): Promise<boolean>;
+		isFormattingEnabled?(document: TextDocument, context: ServiceContext): Result<boolean>;
+		isValidationEnabled?(document: TextDocument, context: ServiceContext): Result<boolean>;
+		isSuggestionsEnabled?(document: TextDocument, context: ServiceContext): Result<boolean>;
+		isAutoClosingTagsEnabled?(document: TextDocument, context: ServiceContext): Result<boolean>;
 	} = {},
 ): ServicePlugin {
 	const basicTriggerCharacters = getBasicTriggerCharacters(ts.version);

--- a/packages/yaml/index.ts
+++ b/packages/yaml/index.ts
@@ -1,7 +1,7 @@
-import type { ServicePluginInstance, ServicePlugin, DocumentSelector, ServiceContext, Disposable } from '@volar/language-service';
+import type { Disposable, DocumentSelector, Result, ServiceContext, ServicePlugin, ServicePluginInstance } from '@volar/language-service';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import * as yaml from 'yaml-language-server';
 import { URI, Utils } from 'vscode-uri';
+import * as yaml from 'yaml-language-server';
 
 export interface Provide {
 	'yaml/languageService': () => yaml.LanguageService;
@@ -22,7 +22,7 @@ export function create({
 			},
 		};
 	},
-	getLanguageSettings = async () => {
+	getLanguageSettings = () => {
 		return {
 			completion: true,
 			customTags: [],
@@ -39,7 +39,7 @@ export function create({
 }: {
 	documentSelector?: DocumentSelector;
 	getWorkspaceContextService?(context: ServiceContext): yaml.WorkspaceContextService;
-	getLanguageSettings?(context: ServiceContext): Promise<yaml.LanguageSettings>;
+	getLanguageSettings?(context: ServiceContext): Result<yaml.LanguageSettings>;
 	onDidChangeLanguageSettings?(listener: () => void, context: ServiceContext): Disposable;
 } = {}): ServicePlugin {
 	return {

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -24,7 +24,8 @@
 		"url": "https://github.com/remcohaszing"
 	},
 	"dependencies": {
-		"yaml-language-server": "1.14.0"
+		"yaml-language-server": "1.14.0",
+		"vscode-uri": "^3.0.8"
 	},
 	"devDependencies": {
 		"vscode-languageserver-textdocument": "^1.0.11"


### PR DESCRIPTION
Affected services: css, html, json, markdown, prettyhtml, pug-beautify, pug, sass-formatter, typescript, yaml

- Most services now expose `documentSelector` / `*DocumentSelector` option.

- Services with formatting capabilities now expose the `isFormattingEnabled` option.

- **css:** now obtains `LanguageService` instances on demand.

- **css:** no longer has built-in support for `postcss` language. If necessary, you can configure `scssDocumentSelector: ['scss', 'postcss']` option.

- **html:** if you need to update custom data, now you should implement the `onDidChangeCustomData` option instead of inject `'html/updateCustomData'` key.

Refactoring of the prettier service plugin will be done in a separate PR.