### PR TITLE
feat(prettier): Allow a Prettier instance to be optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 *.js
 *.map
 *.tgz
+.DS_Store

--- a/packages/prettier/index.ts
+++ b/packages/prettier/index.ts
@@ -56,83 +56,85 @@ export function create(
 	return {
 		name: 'prettier',
 		create(context): ServicePluginInstance {
+			const languages = options.languages ?? ['html', 'css', 'scss', 'typescript', 'javascript'];
 
 			let prettier: typeof import('prettier');
 			try {
 				prettier = options.prettier
 					?? options.getPrettier?.(context.env)
 					?? require('prettier');
+
+				return {
+					async provideDocumentFormattingEdits(document, _, formatOptions) {
+						if (!prettier) return;
+						if (!languages.includes(document.languageId)) {
+							return;
+						}
+
+						const filePath = URI.parse(document.uri).fsPath;
+						const fileInfo = await prettier.getFileInfo(filePath, { ignorePath: '.prettierignore', resolveConfig: false });
+
+						if (fileInfo.ignored) {
+							return;
+						}
+
+						const filePrettierOptions = await getPrettierConfig(
+							filePath,
+							prettier,
+							options.resolveConfigOptions
+						);
+
+						const editorPrettierOptions = await context.env.getConfiguration?.('prettier', document.uri);
+						const ideFormattingOptions =
+							formatOptions !== undefined && options.useIdeOptionsFallback // We need to check for options existing here because some editors might not have it
+								? {
+									tabWidth: formatOptions.tabSize,
+									useTabs: !formatOptions.insertSpaces,
+								}
+								: {};
+
+						// Return a config with the following cascade:
+						// - Prettier config file should always win if it exists, if it doesn't:
+						// - Prettier config from the VS Code extension is used, if it doesn't exist:
+						// - Use the editor's basic configuration settings
+						const prettierOptions = returnObjectIfHasKeys(filePrettierOptions) || returnObjectIfHasKeys(editorPrettierOptions) || ideFormattingOptions;
+
+						const currentPrettierConfig: Options = {
+							...(options.additionalOptions
+								? await options.additionalOptions(prettierOptions)
+								: prettierOptions),
+							filepath: filePath,
+						};
+
+						if (!options.ignoreIdeOptions) {
+							currentPrettierConfig.useTabs = !formatOptions.insertSpaces;
+							currentPrettierConfig.tabWidth = formatOptions.tabSize;
+						}
+
+						const fullText = document.getText();
+						let oldText = fullText;
+
+						const isHTML = document.languageId === "html";
+						if (isHTML && options.html?.breakContentsFromTags) {
+							oldText = oldText
+								.replace(/(<[a-z][^>]*>)([^ \n])/gi, "$1 $2")
+								.replace(/([^ \n])(<\/[a-z][a-z0-9\t\n\r -]*>)/gi, "$1 $2");
+						}
+
+						return [{
+							newText: await prettier.format(oldText, currentPrettierConfig),
+							range: {
+								start: document.positionAt(0),
+								end: document.positionAt(fullText.length),
+							},
+						}];
+					},
+				};
 			} catch (e) {
 				if (!options.allowImportError) throw new Error("Could not load Prettier: " + e);
 			}
-			const languages = options.languages ?? ['html', 'css', 'scss', 'typescript', 'javascript'];
 
-			return {
-				async provideDocumentFormattingEdits(document, _, formatOptions) {
-					if (!prettier) return;
-					if (!languages.includes(document.languageId)) {
-						return;
-					}
-
-					const filePath = URI.parse(document.uri).fsPath;
-					const fileInfo = await prettier.getFileInfo(filePath, { ignorePath: '.prettierignore', resolveConfig: false });
-
-					if (fileInfo.ignored) {
-						return;
-					}
-
-					const filePrettierOptions = await getPrettierConfig(
-						filePath,
-						prettier,
-						options.resolveConfigOptions
-					);
-
-					const editorPrettierOptions = await context.env.getConfiguration?.('prettier', document.uri);
-					const ideFormattingOptions =
-						formatOptions !== undefined && options.useIdeOptionsFallback // We need to check for options existing here because some editors might not have it
-							? {
-								tabWidth: formatOptions.tabSize,
-								useTabs: !formatOptions.insertSpaces,
-							}
-							: {};
-
-					// Return a config with the following cascade:
-					// - Prettier config file should always win if it exists, if it doesn't:
-					// - Prettier config from the VS Code extension is used, if it doesn't exist:
-					// - Use the editor's basic configuration settings
-					const prettierOptions = returnObjectIfHasKeys(filePrettierOptions) || returnObjectIfHasKeys(editorPrettierOptions) || ideFormattingOptions;
-
-					const currentPrettierConfig: Options = {
-						...(options.additionalOptions
-							? await options.additionalOptions(prettierOptions)
-							: prettierOptions),
-						filepath: filePath,
-					};
-
-					if (!options.ignoreIdeOptions) {
-						currentPrettierConfig.useTabs = !formatOptions.insertSpaces;
-						currentPrettierConfig.tabWidth = formatOptions.tabSize;
-					}
-
-					const fullText = document.getText();
-					let oldText = fullText;
-
-					const isHTML = document.languageId === "html";
-					if (isHTML && options.html?.breakContentsFromTags) {
-						oldText = oldText
-							.replace(/(<[a-z][^>]*>)([^ \n])/gi, "$1 $2")
-							.replace(/([^ \n])(<\/[a-z][a-z0-9\t\n\r -]*>)/gi, "$1 $2");
-					}
-
-					return [{
-						newText: await prettier.format(oldText, currentPrettierConfig),
-						range: {
-							start: document.positionAt(0),
-							end: document.positionAt(fullText.length),
-						},
-					}];
-				},
-			};
+			return {};
 		},
 	};
 }


### PR DESCRIPTION
Prior to Volar 2.0, it was possible for upstream consumers to simply not initialize the Prettier plugin if they couldn't find Prettier themselves. This is not possible anymore as the resolving of Prettier has to open inside the plugin's hooks (since you need `env` to try to find Prettier in the first place, and it's not available in createServicePlugin)
 
Fix https://github.com/volarjs/services/issues/77