### PR TITLE
chore(markdown): update vscode-markdown-languageservice to 0.5 alpha

### DIFF
--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -26,7 +26,7 @@
 	"dependencies": {
 		"markdown-it": "^13.0.2",
 		"vscode-jsonrpc": "^8.2.0",
-		"vscode-markdown-languageservice": "~0.4.0-alpha.7",
+		"vscode-markdown-languageservice": "~0.5.0-alpha.1",
 		"vscode-uri": "^3.0.8"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,25 +10,25 @@ importers:
     devDependencies:
       '@lerna-lite/cli':
         specifier: latest
-        version: 3.3.0(@lerna-lite/exec@3.3.0)(@lerna-lite/publish@3.3.0)(@lerna-lite/version@3.3.0)(typescript@5.3.3)
+        version: 3.3.1(@lerna-lite/exec@3.3.1)(@lerna-lite/publish@3.3.1)(@lerna-lite/version@3.3.1)(typescript@5.4.2)
       '@lerna-lite/exec':
         specifier: latest
-        version: 3.3.0(@lerna-lite/publish@3.3.0)(typescript@5.3.3)
+        version: 3.3.1(@lerna-lite/publish@3.3.1)(typescript@5.4.2)
       '@lerna-lite/publish':
         specifier: latest
-        version: 3.3.0(@lerna-lite/exec@3.3.0)(typescript@5.3.3)
+        version: 3.3.1(@lerna-lite/exec@3.3.1)(typescript@5.4.2)
       '@volar/language-service':
         specifier: ~2.1.0
         version: 2.1.0
       '@volar/tsl-config':
         specifier: latest
-        version: 0.0.0-20240315(tsl@0.0.9)
+        version: 0.0.0-20240315.2(tsl@0.0.10)
       tsl:
         specifier: latest
-        version: 0.0.9(typescript@5.3.3)
+        version: 0.0.10(typescript@5.4.2)
       typescript:
         specifier: latest
-        version: 5.3.3
+        version: 5.4.2
       vscode-languageserver-protocol:
         specifier: ^3.17.5
         version: 3.17.5
@@ -50,7 +50,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: latest
-        version: 20.11.20
+        version: 20.11.28
 
   packages/emmet:
     dependencies:
@@ -81,7 +81,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: latest
-        version: 20.11.20
+        version: 20.11.28
 
   packages/json:
     dependencies:
@@ -111,8 +111,8 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0
       vscode-markdown-languageservice:
-        specifier: ~0.4.0-alpha.7
-        version: 0.4.0
+        specifier: ~0.5.0-alpha.1
+        version: 0.5.0-alpha.1
       vscode-uri:
         specifier: ^3.0.8
         version: 3.0.8
@@ -135,7 +135,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: latest
-        version: 20.11.20
+        version: 20.11.28
       prettier:
         specifier: ^3.0.3
         version: 3.2.5
@@ -172,7 +172,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: latest
-        version: 20.11.20
+        version: 20.11.28
 
   packages/pug-beautify:
     dependencies:
@@ -185,7 +185,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: latest
-        version: 20.11.20
+        version: 20.11.28
 
   packages/sass-formatter:
     dependencies:
@@ -248,7 +248,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: latest
-        version: 20.11.20
+        version: 20.11.28
 
   packages/yaml:
     dependencies:
@@ -614,8 +614,8 @@ packages:
     resolution: {integrity: sha512-qqNS/YD0Nck5wtQLCPHAfGVgWbbGafxSPjNh0ekYPFSNNqnDH2kamnduzYly8IiADmeVx/MfAE1njMEjVeHTMA==}
     dev: false
 
-  /@lerna-lite/cli@3.3.0(@lerna-lite/exec@3.3.0)(@lerna-lite/publish@3.3.0)(@lerna-lite/version@3.3.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-u3JG4576T0oex9TDIJoB1QOMwZ14FB4h1sae1/FtTUUhPis1loyvdlr2zw2HvPpCtMhv+JTGYpsjslQNFfWigA==}
+  /@lerna-lite/cli@3.3.1(@lerna-lite/exec@3.3.1)(@lerna-lite/publish@3.3.1)(@lerna-lite/version@3.3.1)(typescript@5.4.2):
+    resolution: {integrity: sha512-tniFllcJtrR6SinS1AnDMzviZmnR1fInyIX1HZCIaDiiSz1O3FAM+QmrrFfSHl5HRaPpVGEPMP9KexTKZE+Csw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -639,11 +639,11 @@ packages:
       '@lerna-lite/watch':
         optional: true
     dependencies:
-      '@lerna-lite/core': 3.3.0(typescript@5.3.3)
-      '@lerna-lite/exec': 3.3.0(@lerna-lite/publish@3.3.0)(typescript@5.3.3)
-      '@lerna-lite/init': 3.3.0(typescript@5.3.3)
-      '@lerna-lite/publish': 3.3.0(@lerna-lite/exec@3.3.0)(typescript@5.3.3)
-      '@lerna-lite/version': 3.3.0(@lerna-lite/exec@3.3.0)(@lerna-lite/publish@3.3.0)(typescript@5.3.3)
+      '@lerna-lite/core': 3.3.1(typescript@5.4.2)
+      '@lerna-lite/exec': 3.3.1(@lerna-lite/publish@3.3.1)(typescript@5.4.2)
+      '@lerna-lite/init': 3.3.1(typescript@5.4.2)
+      '@lerna-lite/publish': 3.3.1(@lerna-lite/exec@3.3.1)(typescript@5.4.2)
+      '@lerna-lite/version': 3.3.1(@lerna-lite/exec@3.3.1)(@lerna-lite/publish@3.3.1)(typescript@5.4.2)
       dedent: 1.5.1
       dotenv: 16.4.5
       import-local: 3.1.0
@@ -657,15 +657,15 @@ packages:
       - typescript
     dev: true
 
-  /@lerna-lite/core@3.3.0(typescript@5.3.3):
-    resolution: {integrity: sha512-IpCIvql2LuJJ6UQpsKlOMtYTz0bSa9Gq/hMGkWeT75lVSa9NICYxBAaSXSkMHvoUEPex+y7XVGm2LYbhVCOzPA==}
+  /@lerna-lite/core@3.3.1(typescript@5.4.2):
+    resolution: {integrity: sha512-YkYVaHzdRqOFKtCZcWfRVg44lu1OXErzx9xKruKYjX6qHfUr0zqyNVm6tbzWGy9wPdU4VWw77KKzG+gtIEcGjA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     dependencies:
       '@npmcli/run-script': 7.0.4
       chalk: 5.3.0
       clone-deep: 4.0.1
       config-chain: 1.1.13
-      cosmiconfig: 9.0.0(typescript@5.3.3)
+      cosmiconfig: 9.0.0(typescript@5.4.2)
       dedent: 1.5.1
       execa: 8.0.1
       fs-extra: 11.2.0
@@ -694,14 +694,14 @@ packages:
       - typescript
     dev: true
 
-  /@lerna-lite/exec@3.3.0(@lerna-lite/publish@3.3.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-DSBX0MIieeRGNDl/3Ue1vDE2t9b1t6yhBb+7m8+aLWezKGSYYo7F6Q1sbN08J7vR3Yo0Mj6URgzFb2MqYnBXIw==}
+  /@lerna-lite/exec@3.3.1(@lerna-lite/publish@3.3.1)(typescript@5.4.2):
+    resolution: {integrity: sha512-he6BwrDkGlcSORwMJMzAn4LCgVjkkXvk4/oddPIuQVqX02HC1i5yOckr+g/GHoKbV7XRQcSulD8nJ2nXOI2ReA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     dependencies:
-      '@lerna-lite/cli': 3.3.0(@lerna-lite/exec@3.3.0)(@lerna-lite/publish@3.3.0)(@lerna-lite/version@3.3.0)(typescript@5.3.3)
-      '@lerna-lite/core': 3.3.0(typescript@5.3.3)
-      '@lerna-lite/filter-packages': 3.3.0(typescript@5.3.3)
-      '@lerna-lite/profiler': 3.3.0(typescript@5.3.3)
+      '@lerna-lite/cli': 3.3.1(@lerna-lite/exec@3.3.1)(@lerna-lite/publish@3.3.1)(@lerna-lite/version@3.3.1)(typescript@5.4.2)
+      '@lerna-lite/core': 3.3.1(typescript@5.4.2)
+      '@lerna-lite/filter-packages': 3.3.1(typescript@5.4.2)
+      '@lerna-lite/profiler': 3.3.1(typescript@5.4.2)
       chalk: 5.3.0
       dotenv: 16.4.5
       npmlog: 7.0.1
@@ -718,11 +718,11 @@ packages:
       - typescript
     dev: true
 
-  /@lerna-lite/filter-packages@3.3.0(typescript@5.3.3):
-    resolution: {integrity: sha512-rybTGTEP9ud0IcFKJbnwGw6GSnTFltjA+hmk9KsCS5M48/Cu5GFDMgrIz0OPP7TcAqs/Qu/is1SoJMwLVo8+kg==}
+  /@lerna-lite/filter-packages@3.3.1(typescript@5.4.2):
+    resolution: {integrity: sha512-YHK6TazjA2yJsWnsKuHbb8/pobLWjEwv4HaHUU3n9ZiRkfgckRPZV2MYQFfySnTaTJDqUHMVuSmnfaUugTr03w==}
     engines: {node: ^18.0.0 || >=20.0.0}
     dependencies:
-      '@lerna-lite/core': 3.3.0(typescript@5.3.3)
+      '@lerna-lite/core': 3.3.1(typescript@5.4.2)
       multimatch: 7.0.0
       npmlog: 7.0.1
     transitivePeerDependencies:
@@ -732,11 +732,11 @@ packages:
       - typescript
     dev: true
 
-  /@lerna-lite/init@3.3.0(typescript@5.3.3):
-    resolution: {integrity: sha512-lYhswm6lid8GhZ8My93GUhoN/+NW5E+5FwFKInLNUsFaNY7Oxb4kGmIrxShY3uAe0fj6PytohYFJy+IeeEGYoQ==}
+  /@lerna-lite/init@3.3.1(typescript@5.4.2):
+    resolution: {integrity: sha512-dYTEfwz4xv43BeILWjWxijhpTcKtHqIQEx1QVEmzOVJu6lbpATkbFYQ5DO4BXElyx/5hjNLHptKnDIen9T5Peg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     dependencies:
-      '@lerna-lite/core': 3.3.0(typescript@5.3.3)
+      '@lerna-lite/core': 3.3.1(typescript@5.4.2)
       fs-extra: 11.2.0
       p-map: 7.0.1
       write-json-file: 5.0.0
@@ -747,11 +747,11 @@ packages:
       - typescript
     dev: true
 
-  /@lerna-lite/profiler@3.3.0(typescript@5.3.3):
-    resolution: {integrity: sha512-tjcAIzEpxI4XuCU0loneyi1e6XeG+fk1DIsBTjZBykHac69DEjFjoihfrfQJDpqJD7zqTH/m/o8IQ26ALr/Rng==}
+  /@lerna-lite/profiler@3.3.1(typescript@5.4.2):
+    resolution: {integrity: sha512-EZYu512G+pdgn58BJwBaqfiYMqfhiYKrWNf8bVsEYI8nLSrCgfyq9ZSxMzz+QRx6sv//41KhkACpc2RU9V4yyA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     dependencies:
-      '@lerna-lite/core': 3.3.0(typescript@5.3.3)
+      '@lerna-lite/core': 3.3.1(typescript@5.4.2)
       fs-extra: 11.2.0
       npmlog: 7.0.1
       upath: 2.0.1
@@ -762,14 +762,14 @@ packages:
       - typescript
     dev: true
 
-  /@lerna-lite/publish@3.3.0(@lerna-lite/exec@3.3.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-3DxprCHf+CTUmSfLhalui+v2Ej8Beo//Ls7jhP2IsMxUPvVBE4clOtyCpJdwUJ/1eNvkq9WsAnkwx+HqG9xOUQ==}
+  /@lerna-lite/publish@3.3.1(@lerna-lite/exec@3.3.1)(typescript@5.4.2):
+    resolution: {integrity: sha512-NmuO+nZ09S1QP+iigr4MrdROfOSL17bscoVKVsiBL5pHwX11lv6UyqRdpDDcG9UbExfRtyeDEFy37GfpPpD0iQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     dependencies:
-      '@lerna-lite/cli': 3.3.0(@lerna-lite/exec@3.3.0)(@lerna-lite/publish@3.3.0)(@lerna-lite/version@3.3.0)(typescript@5.3.3)
-      '@lerna-lite/core': 3.3.0(typescript@5.3.3)
-      '@lerna-lite/version': 3.3.0(@lerna-lite/exec@3.3.0)(@lerna-lite/publish@3.3.0)(typescript@5.3.3)
-      '@npmcli/arborist': 7.3.1
+      '@lerna-lite/cli': 3.3.1(@lerna-lite/exec@3.3.1)(@lerna-lite/publish@3.3.1)(@lerna-lite/version@3.3.1)(typescript@5.4.2)
+      '@lerna-lite/core': 3.3.1(typescript@5.4.2)
+      '@lerna-lite/version': 3.3.1(@lerna-lite/exec@3.3.1)(@lerna-lite/publish@3.3.1)(typescript@5.4.2)
+      '@npmcli/arborist': 7.4.0
       byte-size: 8.1.1
       chalk: 5.3.0
       columnify: 1.6.0
@@ -803,12 +803,12 @@ packages:
       - typescript
     dev: true
 
-  /@lerna-lite/version@3.3.0(@lerna-lite/exec@3.3.0)(@lerna-lite/publish@3.3.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-Mi75gbjQreIDKWG9gtaolzuVua2hutp/tx4oXYkX0MENvWB5zmIYZCEqOawqvGSFSt+esD7P0MIU896aV2qyAQ==}
+  /@lerna-lite/version@3.3.1(@lerna-lite/exec@3.3.1)(@lerna-lite/publish@3.3.1)(typescript@5.4.2):
+    resolution: {integrity: sha512-0Kes5H0H8+tZSTLMTf5ArZTIijROSwgvJsnd5o7z6XvYZM8cq9ED63tpzgX9GKXyqnjZH4mlHpcQr5lpmABJFA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     dependencies:
-      '@lerna-lite/cli': 3.3.0(@lerna-lite/exec@3.3.0)(@lerna-lite/publish@3.3.0)(@lerna-lite/version@3.3.0)(typescript@5.3.3)
-      '@lerna-lite/core': 3.3.0(typescript@5.3.3)
+      '@lerna-lite/cli': 3.3.1(@lerna-lite/exec@3.3.1)(@lerna-lite/publish@3.3.1)(@lerna-lite/version@3.3.1)(typescript@5.4.2)
+      '@lerna-lite/core': 3.3.1(typescript@5.4.2)
       '@octokit/plugin-enterprise-rest': 6.0.1
       '@octokit/rest': 20.0.2
       chalk: 5.3.0
@@ -822,7 +822,7 @@ packages:
       get-stream: 8.0.1
       git-url-parse: 14.0.0
       graceful-fs: 4.2.11
-      is-stream: 3.0.0
+      is-stream: 4.0.1
       load-json-file: 7.0.1
       make-dir: 4.0.0
       minimatch: 9.0.3
@@ -889,8 +889,8 @@ packages:
       - supports-color
     dev: true
 
-  /@npmcli/arborist@7.3.1:
-    resolution: {integrity: sha512-qjMywu8clYczZE2SlLZWVOujAyiJEHHSEzapIXpuMURRH/tfY0KPKvGPyjvV041QsGN3tsWeaTUHcOi59wscSw==}
+  /@npmcli/arborist@7.4.0:
+    resolution: {integrity: sha512-VFsUaTrV8NR+0E2I+xhp6pPC5eAbMmSMSMZbS57aogLc6du6HWBPATFOaiNWwp1QTFVeP4aLhYixQM9hHfaAsA==}
     engines: {node: ^16.14.0 || >=18.0.0}
     hasBin: true
     dependencies:
@@ -1331,27 +1331,27 @@ packages:
       defer-to-connect: 1.1.3
     dev: false
 
-  /@tsslint/cli@0.0.9(typescript@5.3.3):
-    resolution: {integrity: sha512-XPljG/PoVc3f2ca1phim/bq4JEien+zZMAi+na8s46EawCRLcqMyokysRKWOIijFLuCAjGKu9jLkW0bS56ar0g==}
+  /@tsslint/cli@0.0.10(typescript@5.4.2):
+    resolution: {integrity: sha512-0F0LbGUbFbVinvNjA3qCyx6ynZA4ScBR2Tr1ZHOXog6BnR9wrvXMqPA/cud2GMftO7mRDMtsh1mBop9NsZeHtQ==}
     hasBin: true
     peerDependencies:
       typescript: '*'
     dependencies:
       '@clack/prompts': 0.7.0
-      '@tsslint/config': 0.0.9
-      '@tsslint/core': 0.0.9
+      '@tsslint/config': 0.0.10
+      '@tsslint/core': 0.0.10
       glob: 10.3.10
-      typescript: 5.3.3
+      typescript: 5.4.2
     dev: true
 
-  /@tsslint/config@0.0.9:
-    resolution: {integrity: sha512-zxePomKGSDga8zVxvM7tcA5LFmqROzpn8jz//uJlNy2a61mMvWv10abO2ukvhVFfMzbq8pocj0zCRYkjCE9kNw==}
+  /@tsslint/config@0.0.10:
+    resolution: {integrity: sha512-WdLrCFBH1VT6VOIaFifsIZrMeiLO4Vss5HGwxx/G+rWl90BwJXXOtIBCr00nDPISv+YNokD4QYMSJWrjlvBVCQ==}
     dependencies:
       esbuild: 0.19.12
     dev: true
 
-  /@tsslint/core@0.0.9:
-    resolution: {integrity: sha512-BVQWAb3SuK7HTNbNuTFTidSCWQ7wGcQ3FD/WSqraeWNNVH4u2nbS5o1uJ0CwQhPvDhHP4QDKi94Qr/gappZaeQ==}
+  /@tsslint/core@0.0.10:
+    resolution: {integrity: sha512-21RrlBbKeTwk2HPmwG9iNBws3F+S1MWsGT4gI0mchbJBQf9THMNcalK2c24knDObSjryfRdeWuIBFalldOaPOw==}
     dependencies:
       error-stack-parser: 2.1.4
       source-map-support: 0.5.21
@@ -1373,7 +1373,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.28
     dev: false
 
   /@types/linkify-it@3.0.5:
@@ -1391,8 +1391,8 @@ packages:
     resolution: {integrity: sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==}
     dev: true
 
-  /@types/node@20.11.20:
-    resolution: {integrity: sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==}
+  /@types/node@20.11.28:
+    resolution: {integrity: sha512-M/GPWVS2wLkSkNHVeLkrF2fD5Lx5UC4PxA0uZcKc6QqbIQUJyW1jVjueJYi1z8n0I5PxYrtpnPnWglE+y9A0KA==}
     dependencies:
       undici-types: 5.26.5
 
@@ -1407,7 +1407,7 @@ packages:
   /@types/responselike@1.0.3:
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.28
     dev: false
 
   /@types/semver@7.5.8:
@@ -1432,7 +1432,7 @@ packages:
   /@types/vfile@3.0.2:
     resolution: {integrity: sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==}
     dependencies:
-      '@types/node': 20.11.20
+      '@types/node': 20.11.28
       '@types/unist': 2.0.10
       '@types/vfile-message': 2.0.0
     dev: false
@@ -1459,12 +1459,12 @@ packages:
     dependencies:
       muggle-string: 0.4.1
 
-  /@volar/tsl-config@0.0.0-20240315(tsl@0.0.9):
-    resolution: {integrity: sha512-axWGYd2nEVW5U/ZLDltNwf/Y21mEoRUXMaHIWw+dwJN/RuKEyUZnl+YZpbvRD/CQQxw+r/fvq1AWcolsx5tqYQ==}
+  /@volar/tsl-config@0.0.0-20240315.2(tsl@0.0.10):
+    resolution: {integrity: sha512-bv57xhmegLkfjW0/FZL/sberfmUch7yLAkXlRXj5KxHPYCjIU4T1ciPuLWrtVzCa+o0q7ykQ6aR+Q/z7MSMf6w==}
     peerDependencies:
       tsl: '*'
     dependencies:
-      tsl: 0.0.9(typescript@5.3.3)
+      tsl: 0.0.10(typescript@5.4.2)
     dev: true
 
   /@vscode/emmet-helper@2.9.2:
@@ -2099,7 +2099,7 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: false
 
-  /cosmiconfig@9.0.0(typescript@5.3.3):
+  /cosmiconfig@9.0.0(typescript@5.4.2):
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -2112,7 +2112,7 @@ packages:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
-      typescript: 5.3.3
+      typescript: 5.4.2
     dev: true
 
   /cross-spawn@5.1.0:
@@ -3383,6 +3383,11 @@ packages:
   /is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
+  /is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
     dev: true
 
   /is-text-path@2.0.0:
@@ -5304,13 +5309,13 @@ packages:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
     dev: false
 
-  /tsl@0.0.9(typescript@5.3.3):
-    resolution: {integrity: sha512-jtBGsgQ88GPnwJytfVbdInd0x0KBv5kmT7xlVMSEdxR63AwEWpbpkEOECCJG/MNaxQ94N8S50yXmM0M1trk5cA==}
+  /tsl@0.0.10(typescript@5.4.2):
+    resolution: {integrity: sha512-hy7OuMp55TkicjtDKgpg1q2xq1Dboi2YWM+JexNEP4MZr3n+Fr5KXv64ZXzJx1NbPhMHbOuM36bHcFFXE4Ofcg==}
     hasBin: true
     dependencies:
-      '@tsslint/cli': 0.0.9(typescript@5.3.3)
-      '@tsslint/config': 0.0.9
-      '@tsslint/core': 0.0.9
+      '@tsslint/cli': 0.0.10(typescript@5.4.2)
+      '@tsslint/config': 0.0.10
+      '@tsslint/core': 0.0.10
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -5426,8 +5431,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript@5.3.3:
-    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+  /typescript@5.4.2:
+    resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -5820,14 +5825,13 @@ packages:
       vscode-languageserver-protocol: 3.16.0
     dev: false
 
-  /vscode-markdown-languageservice@0.4.0:
-    resolution: {integrity: sha512-3C8pZlC0ofHEYmWwHgenxL6//XrpkrgyytrqNpMlft46q9uBxSUfcXtEGt7wIDNLWsvmgqPqHBwEnBFtLwrWFA==}
+  /vscode-markdown-languageservice@0.5.0-alpha.1:
+    resolution: {integrity: sha512-7uVtRSr4+/xlsml9QtBkBAHPmtBv71CKEj6zhPTERYZEOHCwFsue1EHkESWBOGuqQ1NSLXPnHWENcDh5VD+bNw==}
     dependencies:
       '@vscode/l10n': 0.0.10
       node-html-parser: 6.1.12
       picomatch: 2.3.1
-      vscode-languageserver-textdocument: 1.0.11
-      vscode-languageserver-types: 3.17.5
+      vscode-languageserver-protocol: 3.17.5
       vscode-uri: 3.0.8
     dev: false
 


### PR DESCRIPTION
This fixes some problems with missing dependencies in 0.4 stable.