### PR TITLE
feat(yaml): implement `onTypeFormattingEdits`

### DIFF
--- a/packages/yaml/index.ts
+++ b/packages/yaml/index.ts
@@ -59,6 +59,9 @@ export function create({
 			},
 			definitionProvider: true,
 			diagnosticProvider: {},
+			documentOnTypeFormattingProvider: {
+				triggerCharacters: ['\n']
+			},
 			documentSymbolProvider: true,
 			hoverProvider: true,
 			documentLinkProvider: {},
@@ -146,6 +149,12 @@ export function create({
 				provideFoldingRanges(document) {
 					return worker(document, () => {
 						return ls.getFoldingRanges(document, context.env.clientCapabilities?.textDocument?.foldingRange ?? {});
+					});
+				},
+
+				provideOnTypeFormattingEdits(document, position, key, options) {
+					return worker(document, () => {
+						return ls.doDocumentOnTypeFormatting(document, { ch: key, options, position, textDocument: document });
 					});
 				},
 


### PR DESCRIPTION
I understand now this is unrelated to `provideDocumentFormattingEdits` and does not use Prettier, which is the reason this wasn’t implemented initially.