### PR TITLE
fix: lack of completion

### DIFF
--- a/packages/pug/index.ts
+++ b/packages/pug/index.ts
@@ -63,8 +63,8 @@ export function create({
 			return {
 				...htmlService,
 				dispose() {
-						htmlService.dispose?.();
-						disposable?.dispose();
+					htmlService.dispose?.();
+					disposable?.dispose();
 				},
 				provide: {
 					'pug/pugDocument': getPugDocument,
@@ -72,7 +72,7 @@ export function create({
 				},
 
 				async provideCompletionItems(document, position, _) {
-					return worker(document, pugDocument => {
+					return await worker(document, pugDocument => {
 						return pugLs.doComplete(pugDocument, position, context, htmlService.provide['html/documentContext']() /** TODO: CompletionConfiguration */);
 					});
 				},
@@ -99,7 +99,7 @@ export function create({
 				},
 
 				async provideHover(document, position) {
-					return worker(document, async pugDocument => {
+					return await worker(document, async pugDocument => {
 
 						const hoverSettings = await context.env.getConfiguration?.<html.HoverSettings>('html.hover');
 
@@ -120,7 +120,7 @@ export function create({
 				},
 
 				async provideDocumentSymbols(document, token) {
-					return worker(document, async pugDoc => {
+					return await worker(document, async pugDoc => {
 
 						const htmlResult = await htmlService.provideDocumentSymbols?.(pugDoc.docs[1], token) ?? [];
 						const pugResult = htmlResult.map(htmlSymbol => transformDocumentSymbol(
@@ -149,7 +149,7 @@ export function create({
 					if (document.offsetAt(selection) !== change.rangeOffset + change.text.length) {
 						return;
 					}
-					return worker(document, async pugDocument => {
+					return await worker(document, async pugDocument => {
 						if (change.rangeLength === 0 && change.text.endsWith('=')) {
 
 							const enabled = (await context.env.getConfiguration?.<boolean>(configurationSections.autoCreateQuotes)) ?? true;
@@ -179,7 +179,9 @@ export function create({
 				return callback(pugDocument);
 			}
 			async function initialize() {
-				if(!getCustomData) return;
+				if (!getCustomData) {
+					return;
+				}
 				const customData = await getCustomData(context);
 				htmlService.provide['html/languageService']().setDataProviders(useDefaultDataProvider, customData);
 			}

--- a/packages/pug/index.ts
+++ b/packages/pug/index.ts
@@ -59,7 +59,6 @@ export function create({
 			const pugLs = pug.getLanguageService(htmlService.provide['html/languageService']());
 
 			return {
-				...htmlService,
 				provide: {
 					'pug/pugDocument': getPugDocument,
 					'pug/languageService': () => pugLs,

--- a/packages/pug/index.ts
+++ b/packages/pug/index.ts
@@ -34,7 +34,6 @@ export function create({
 		onDidChangeCustomData,
 	});
 	return {
-		..._htmlService,
 		name: 'pug',
 		capabilities: {
 			completionProvider: {


### PR DESCRIPTION
There seem to be something wrong with the pug template since `Vue - official` was upgraded to v2.0, and I found a related issue that still hasn't been resolved, which you can check out [here](https://github.com/vuejs/language-tools/issues/4235).

I compared `volar-service-pug` to `volar-service-html` and found that the `initialize` function was missing in `volar-service-pug`, which resulted in an inability to accurately obtain `customData`.

I tried making changes to the code and repackaging the plugin, and finally, the completion in the pug template worked as expected.

I am new to this project and not sure if my changes are appropriate, but I hope they help.