### PR TITLE
fix(yaml): add missing formatting provider

### DIFF
--- a/packages/yaml/index.ts
+++ b/packages/yaml/index.ts
@@ -59,6 +59,7 @@ export function create({
 			},
 			definitionProvider: true,
 			diagnosticProvider: {},
+			documentFormattingProvider: true,
 			documentOnTypeFormattingProvider: {
 				triggerCharacters: ['\n']
 			},
@@ -149,6 +150,12 @@ export function create({
 				provideFoldingRanges(document) {
 					return worker(document, () => {
 						return ls.getFoldingRanges(document, context.env.clientCapabilities?.textDocument?.foldingRange ?? {});
+					});
+				},
+
+				provideDocumentFormattingEdits(document) {
+					return worker(document, () => {
+						return ls.doFormat(document);
 					});
 				},
 


### PR DESCRIPTION
`ls.doFormat` has another param with type `CustomFormatterOptions`, in this PR this is unused - I am not 100% sure about this.