### PR TITLE
Add readme compatability note

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,7 @@
+## ⚠️ "Vue - Official" Extension Compatibility Note
+
+Please note that services in this repository are designed to work with the Volar Language Features (Volar) extension (version < 2), which supports the use of volar.config.js to load custom plugins. Services in this repository are not compatible with the new "Vue - Official" plugin.
+
 # Services
 
 |                             | Backend                                                                                                                                                       | AST Provide | IntelliSense | Diagnostic | Formatting |


### PR DESCRIPTION
### Description:
It's important to inform the community when there are new major releases of a platform or extension that require migration and are no longer compatible with your repository. Many users I am sure, including myself, have spent hours trying to figure out why it's no longer possible to make use of the services in this repository, despite that it seems to be actively maintained.

### Changes:
- Added a compatibility note to `readme.md` to inform users about the supported extension and its version.

### Reason for the Change:
#82 To prevent user confusion about service compatibility with different versions of the Vue extension