### PR TITLE
fix(css): handle trailing line comments in embedded styles

### DIFF
--- a/packages/css/index.ts
+++ b/packages/css/index.ts
@@ -289,10 +289,12 @@ export function create({
 						let suffixes = [];
 
 						if (codeOptions?.initialIndentLevel) {
+							const documentText = document.getText();
+							const lastSuffix = endWithNewLine(documentText) ? '}' : '\n}';
 							for (let i = 0; i < codeOptions.initialIndentLevel; i++) {
 								if (i === codeOptions.initialIndentLevel - 1) {
 									prefixes.push('_', '{');
-									suffixes.unshift('}');
+									suffixes.unshift(lastSuffix);
 								}
 								else {
 									prefixes.push('_', '{\n');
@@ -303,7 +305,7 @@ export function create({
 								document.uri,
 								document.languageId,
 								document.version,
-								prefixes.join('') + document.getText() + suffixes.join(''),
+								prefixes.join('') + documentText + suffixes.join(''),
 							);
 							formatRange = {
 								start: formatDocument.positionAt(0),
@@ -336,18 +338,17 @@ export function create({
 						return edits;
 
 						function ensureNewLines(newText: string) {
-							const prefix = '_ {';
-							const suffix = '}';
+							const verifySuffix = endWithNewLine(newText) ? '}' : '\n}';
 							const verifyDocument = TextDocument.create(
 								document.uri,
 								document.languageId,
 								document.version,
-								prefix + newText + '\n' + suffix,
+								'_ {' + newText + verifySuffix,
 							);
 							const verifyEdits = cssLs.format(verifyDocument, undefined, formatOptions);
 							let verifyText = TextDocument.applyEdits(verifyDocument, verifyEdits);
-							verifyText = verifyText.trimStart().slice(prefix.length);
-							verifyText = verifyText.trimEnd().slice(0, -suffix.length);
+							verifyText = verifyText.trimStart().slice('_'.length);
+							verifyText = verifyText.trim().slice('{'.length, -'}'.length);
 							if (startWithNewLine(verifyText) !== startWithNewLine(newText)) {
 								if (startWithNewLine(verifyText)) {
 									newText = '\n' + newText;

--- a/packages/css/index.ts
+++ b/packages/css/index.ts
@@ -336,16 +336,18 @@ export function create({
 						return edits;
 
 						function ensureNewLines(newText: string) {
+							const prefix = '_ {';
+							const suffix = '}';
 							const verifyDocument = TextDocument.create(
 								document.uri,
 								document.languageId,
 								document.version,
-								'_ {' + newText + '}',
+								prefix + newText + '\n' + suffix,
 							);
 							const verifyEdits = cssLs.format(verifyDocument, undefined, formatOptions);
 							let verifyText = TextDocument.applyEdits(verifyDocument, verifyEdits);
-							verifyText = verifyText.trimStart().slice('_'.length);
-							verifyText = verifyText.trim().slice('{'.length, -'}'.length);
+							verifyText = verifyText.trimStart().slice(prefix.length);
+							verifyText = verifyText.trimEnd().slice(0, -suffix.length);
 							if (startWithNewLine(verifyText) !== startWithNewLine(newText)) {
 								if (startWithNewLine(verifyText)) {
 									newText = '\n' + newText;


### PR DESCRIPTION
 ## Summary                                                
                                                                                                           
  This fixes an edge case in embedded CSS formatting when the formatted content ends with a line comment.                                                                                
                                                                                                           
  `ensureNewLines()` verifies whether formatted embedded content should start or end with a newline by wrapping it in a synthetic CSS rule:                                               
                                                                                                           
  ```ts                                                     
  '_ {' + newText + '}'
  ```
                                                                                                           
  However, languages such as SCSS and Less support `//` line comments. When `newText` ends with a line comment, the appended closing brace becomes part of that comment instead of closing the synthetic rule:                                                      
                                                            
  ```scss                                                                                                  
  // }                                                      
  ```

  As a result, the verification document no longer represents the intended wrapper structure, and the trailing newline check can produce an incorrect result.
                                                                                                           
  This change places the synthetic closing brace on the next line and trims the wrapper using explicit prefix/suffix lengths.                                                            
                                                                                                           
  ## Example                                                

  For embedded SCSS or Less content like this:                                                             
   
  ```scss                                                                                                  
  // .container {                                           
  //   height: 100vh;                                                                                      
  // }                                                      
  ```
                                                                                                           
  the formatter should preserve the trailing newline when required by the embedding host document.                                                                                 
                                                                                                           
  Without this fix, downstream consumers can lose that newline and merge following host content onto the final comment line. One observable downstream case is Vue SFC formatting, where the closing `</style>` tag can be moved onto the same line as the final SCSS or Less comment.                                                                       